### PR TITLE
making it possible to run main.py from wsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Windows：
 - Windows 10/11
 - 微信正在运行
 - 需要管理员权限（读取进程内存）
+- 如果你使用 WSL 运行 main.py，请确保 Windows 和 WSL 中都已安装 Python，并配置好相应的依赖库。
 
 Linux：
 
@@ -83,7 +84,7 @@ python3 main.py decrypt
     "wechat_process": "Weixin.exe"
 }
 ```
-
+如果您使用 WSL (Windows 子系统) 运行该脚本，请确保按照上述示例使用 Windows 文件格式。
 Linux 版 `config.json` 示例：
 
 ```json

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ import json
 import os
 import platform
 import sys
+from wsl_utils import isRunningOnWsl, convertWindowsPath2Wsl
 
 CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.json")
 
@@ -197,6 +198,10 @@ def load_config():
             sys.exit(1)
     else:
         cfg = {**_DEFAULT, **cfg}
+
+    # converting windows path if we are running in wsl
+    if isRunningOnWsl():
+        cfg["db_dir"] = convertWindowsPath2Wsl(cfg["db_dir"])
 
     # 将相对路径转为绝对路径
     base = os.path.dirname(os.path.abspath(__file__))

--- a/config.py
+++ b/config.py
@@ -7,7 +7,7 @@ import json
 import os
 import platform
 import sys
-from wsl_utils import isRunningOnWsl, convertWindowsPath2Wsl
+from wsl_utils import is_running_on_wsl, convert_windows_path_to_wsl
 
 CONFIG_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.json")
 
@@ -200,8 +200,9 @@ def load_config():
         cfg = {**_DEFAULT, **cfg}
 
     # converting windows path if we are running in wsl
-    if isRunningOnWsl():
-        cfg["db_dir"] = convertWindowsPath2Wsl(cfg["db_dir"])
+    if is_running_on_wsl():
+        for key in ("db_dir", "keys_file", "decrypted_dir", "decoded_image_dir"):
+            cfg[key] = convert_windows_path_to_wsl(cfg[key])
 
     # 将相对路径转为绝对路径
     base = os.path.dirname(os.path.abspath(__file__))

--- a/find_all_keys.py
+++ b/find_all_keys.py
@@ -1,7 +1,7 @@
 import functools
 import platform
 import sys
-from wsl_utils import isRunningOnWsl
+from wsl_utils import is_running_on_wsl
 
 
 @functools.lru_cache(maxsize=1)
@@ -10,7 +10,7 @@ def _load_impl():
     if system == "windows":
         import find_all_keys_windows as impl
         return impl
-    if isRunningOnWsl():
+    if is_running_on_wsl():
         import find_all_keys_wsl as impl
         return impl
     if system == "linux":

--- a/find_all_keys.py
+++ b/find_all_keys.py
@@ -1,6 +1,7 @@
 import functools
 import platform
 import sys
+from wsl_utils import isRunningOnWsl
 
 
 @functools.lru_cache(maxsize=1)
@@ -8,6 +9,9 @@ def _load_impl():
     system = platform.system().lower()
     if system == "windows":
         import find_all_keys_windows as impl
+        return impl
+    if isRunningOnWsl():
+        import find_all_keys_wsl as impl
         return impl
     if system == "linux":
         import find_all_keys_linux as impl

--- a/find_all_keys_wsl.py
+++ b/find_all_keys_wsl.py
@@ -1,0 +1,41 @@
+## This script is a simple wsl port of the existing windows script
+## We can not access the memory of a wechat process running on windows from wsl
+## So we simply call the windows version of python to find the keys
+## Requires python to be installed on both wsl and windows with the relevant dependencies
+
+import subprocess
+import os
+import ast
+
+
+BASEPATH = os.path.dirname(os.path.abspath(__file__))
+# convert to a windows format:
+try:
+    WINDOWS_DIR = subprocess.check_output(["wslpath", "-w", BASEPATH], text=True).strip()
+except subprocess.CalledProcessError as e:
+    raise Exception(f"Error: Could not translate WSL path to Windows path: {e}")
+
+
+def get_pids():
+    callWindowsScriptCommand = f"""
+import sys
+sys.path.append(r'{WINDOWS_DIR}')
+from find_all_keys_windows import get_pids
+
+res = get_pids()
+print(res)
+"""
+    result = subprocess.run(["python.exe", "-c", callWindowsScriptCommand], capture_output=True, text=True)
+    
+    if result.returncode != 0:
+        raise Exception("Error while getting the pids on windows")
+    try:
+        resString = result.stdout.strip().split("\n")[-1]
+        return ast.literal_eval(resString)
+    except (SyntaxError, ValueError, IndexError) as e:
+        raise Exception(f"Error while parsing windows output: {e}\nRaw output: {result.stdout}")
+        
+
+def main():
+    windows_full_path = rf"{WINDOWS_DIR}\find_all_keys_windows.py"
+    subprocess.run(["python.exe", windows_full_path])

--- a/find_all_keys_wsl.py
+++ b/find_all_keys_wsl.py
@@ -6,6 +6,7 @@
 import subprocess
 import os
 import ast
+import json
 
 
 BASEPATH = os.path.dirname(os.path.abspath(__file__))
@@ -17,25 +18,32 @@ except subprocess.CalledProcessError as e:
 
 
 def get_pids():
-    callWindowsScriptCommand = f"""
+    result_flag = "#RESULT: "
+    call_windows_script_command = f"""
 import sys
-sys.path.append(r'{WINDOWS_DIR}')
+sys.path.append({json.dumps(WINDOWS_DIR)})
 from find_all_keys_windows import get_pids
 
 res = get_pids()
-print(res)
+print('{result_flag}' + str(res))
 """
-    result = subprocess.run(["python.exe", "-c", callWindowsScriptCommand], capture_output=True, text=True)
+    result = subprocess.run(["python.exe", "-c", call_windows_script_command], capture_output=True, text=True)
     
     if result.returncode != 0:
-        raise Exception("Error while getting the pids on windows")
+        raise Exception(f"Error while getting the pids on windows: {result.stderr}")
     try:
-        resString = result.stdout.strip().split("\n")[-1]
-        return ast.literal_eval(resString)
+        output_lines = result.stdout.strip().split("\n")
+        result_line = next((line for line in output_lines if line.startswith(result_flag)), None)
+        if result_line is None:
+            raise ValueError
+        result_string = result_line[len(result_flag):].strip()
+        return ast.literal_eval(result_string)
     except (SyntaxError, ValueError, IndexError) as e:
         raise Exception(f"Error while parsing windows output: {e}\nRaw output: {result.stdout}")
         
 
 def main():
     windows_full_path = rf"{WINDOWS_DIR}\find_all_keys_windows.py"
-    subprocess.run(["python.exe", windows_full_path])
+    result = subprocess.run(["python.exe", windows_full_path])
+    if result.returncode != 0:
+        raise Exception("error during key extraction on windows")

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ python main.py decrypt  # 提取密钥 + 解密全部数据库
 import json
 import os
 import sys
+from wsl_utils import isRunningOnWsl, convertWindowsPath2Wsl
 
 import functools
 print = functools.partial(print, flush=True)
@@ -34,6 +35,10 @@ def ensure_keys(keys_file, db_dir):
             keys = {}
         # 检查密钥是否匹配当前 db_dir（防止切换账号后误复用旧密钥）
         saved_dir = keys.pop("_db_dir", None)
+
+        if isRunningOnWsl():
+            saved_dir = convertWindowsPath2Wsl(saved_dir)
+
         if saved_dir and os.path.normcase(os.path.normpath(saved_dir)) != os.path.normcase(os.path.normpath(db_dir)):
             print(f"[!] 密钥文件对应的目录已变更，需要重新提取")
             print(f"    旧: {saved_dir}")

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ python main.py decrypt  # 提取密钥 + 解密全部数据库
 import json
 import os
 import sys
-from wsl_utils import isRunningOnWsl, convertWindowsPath2Wsl
+from wsl_utils import is_running_on_wsl, convert_windows_path_to_wsl
 
 import functools
 print = functools.partial(print, flush=True)
@@ -36,8 +36,8 @@ def ensure_keys(keys_file, db_dir):
         # 检查密钥是否匹配当前 db_dir（防止切换账号后误复用旧密钥）
         saved_dir = keys.pop("_db_dir", None)
 
-        if isRunningOnWsl():
-            saved_dir = convertWindowsPath2Wsl(saved_dir)
+        if is_running_on_wsl():
+            saved_dir = convert_windows_path_to_wsl(saved_dir)
 
         if saved_dir and os.path.normcase(os.path.normpath(saved_dir)) != os.path.normcase(os.path.normpath(db_dir)):
             print(f"[!] 密钥文件对应的目录已变更，需要重新提取")

--- a/wsl_utils.py
+++ b/wsl_utils.py
@@ -1,0 +1,13 @@
+import platform
+import os
+import subprocess
+
+def isRunningOnWsl():
+    return (
+        platform.system().lower() == "linux"
+        and os.path.exists('/proc/sys/fs/binfmt_misc/WSLInterop')
+    )
+
+def convertWindowsPath2Wsl(windowsPath):
+    result = subprocess.run(['wslpath', '-u', windowsPath], capture_output=True, text=True, check=True)
+    return result.stdout.strip()

--- a/wsl_utils.py
+++ b/wsl_utils.py
@@ -2,12 +2,18 @@ import platform
 import os
 import subprocess
 
-def isRunningOnWsl():
+def is_running_on_wsl():
     return (
         platform.system().lower() == "linux"
         and os.path.exists('/proc/sys/fs/binfmt_misc/WSLInterop')
     )
 
-def convertWindowsPath2Wsl(windowsPath):
-    result = subprocess.run(['wslpath', '-u', windowsPath], capture_output=True, text=True, check=True)
-    return result.stdout.strip()
+def convert_windows_path_to_wsl(windows_path):
+    if not (windows_path and ("\\" in windows_path or (len(windows_path) > 1 and windows_path[1] == ":"))):
+            return windows_path
+    try:
+        result = subprocess.run(['wslpath', '-u', windows_path], capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        raise Exception(f"Failed to convert windows path '{windows_path}': {e}")
+


### PR DESCRIPTION
Windows Subsystem for Linux (WSL), is a growingly popular linux virtual machine that comes built-in with windows computers.
Currently, the script main.py can not be run from WSL because:
- WSL can not access the memory of windows processes. Since wechat is open on windows, we can not scrape the keys
- file formats are different

This commit makes some simple and minimal changes to port the existing windows scripts to wsl. The key idea is to call the windows version of python as a subprocess to run find_all_keys_windows.py, and to handle file formats appropriately. While not the most efficient strategy, it is the simplest and this process is not the bottleneck for compute time anyway.

The updated tool can now be used in a fully integrated wsl workflow, by launching main.py directly