### PR TITLE
feat: macOS 图片 AES key 从磁盘 kvcomm 缓存派生（解决 #23）

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ claude mcp add wechat -- python C:\Users\你的用户名\wechat-decrypt\mcp_serv
 
 ### 图片解密 (V2 格式)
 
-微信 4.0 (2025-08+) 的 .dat 图片文件使用 AES-128-ECB + XOR 混合加密 (V2 格式)。AES 密钥需要从运行中的微信进程内存中提取：
+微信 4.0 (2025-08+) 的 .dat 图片文件使用 AES-128-ECB + XOR 混合加密 (V2 格式)。AES 密钥的获取方式因平台而异：
+
+**Windows / Linux**（从进程内存扫描）：
 
 ```bash
 # 1. 在微信中打开查看 2-3 张图片（点击看大图）
@@ -216,9 +218,19 @@ python find_image_key_monitor.py
 python find_image_key.py
 ```
 
-密钥会自动保存到 `config.json` 的 `image_aes_key` 字段。之后 `monitor_web.py` 启动时会自动加载密钥，图片消息将显示内联预览。
+> AES 密钥仅在微信查看图片时临时加载到内存中。如果扫描未找到密钥，请先在微信中查看几张图片，然后立即重新运行脚本。
 
-> **注意**: AES 密钥仅在微信查看图片时临时加载到内存中。如果扫描未找到密钥，请先在微信中查看几张图片，然后立即重新运行脚本。
+**macOS**（从磁盘 kvcomm 缓存派生，**无需扫描进程内存**）：
+
+```bash
+python find_image_key_macos.py
+```
+
+无需提前在微信中查看图片，无需 root 权限，无需重签名。脚本会扫描 `~/Library/Containers/com.tencent.xinWeChat/.../app_data/net/kvcomm/key_*.statistic` 文件名提取派生码 `code`，配合 `db_dir` 路径里的 wxid，按 `aes_key = MD5(str(code) + cleaned_wxid)[:16]` / `xor_key = code & 0xFF` 的规则推算密钥，并用一张 V2 `_t.dat` 缩略图做 AES 模板验证。解决 [issue #23](https://github.com/ylytdeng/wechat-decrypt/issues/23)（macOS 内存扫描器 197K 候选全部失败）。
+
+派生算法的发现归功于 [@hicccc77](https://github.com/hicccc77) 在 issue #23 的[评论](https://github.com/ylytdeng/wechat-decrypt/issues/23)，参考实现见其 [WeFlow 项目](https://github.com/hicccc77/WeFlow/blob/dev/electron/services/keyServiceMac.ts)（CC BY-NC-SA 4.0）。本仓库的 `find_image_key_macos.py` 是基于该算法的独立 Python clean-room 实现。
+
+密钥会自动保存到 `config.json` 的 `image_aes_key` / `image_xor_key` 字段。之后 `monitor_web.py` 启动时会自动加载，图片消息将显示内联预览。
 
 ## 文件说明
 
@@ -234,8 +246,9 @@ python find_image_key.py
 | `monitor_web.py` | 实时消息监听 (Web UI + SSE + 图片预览) |
 | `monitor.py` | 实时消息监听 (命令行) |
 | `decode_image.py` | 图片 .dat 文件解密模块 (XOR / V1 / V2) |
-| `find_image_key.py` | 从微信进程内存提取图片 AES 密钥 |
-| `find_image_key_monitor.py` | 持续监控版密钥提取（推荐） |
+| `find_image_key.py` | 从微信进程内存提取图片 AES 密钥（Windows / Linux） |
+| `find_image_key_monitor.py` | 持续监控版密钥提取（Windows / Linux，推荐） |
+| `find_image_key_macos.py` | macOS 版图片密钥派生（从磁盘 kvcomm 缓存推算，无需扫描内存） |
 | `latency_test.py` | 延迟测量诊断工具 |
 | `find_all_keys_macos.c` | macOS 版内存密钥扫描器 (C, Mach VM API) |
 

--- a/find_image_key_macos.py
+++ b/find_image_key_macos.py
@@ -1,0 +1,362 @@
+"""macOS WeChat 4.x 图片 AES key 派生（无需扫描进程内存）。
+
+通过 macOS 微信 4.x 在磁盘上的 kvcomm 缓存文件命名约定，派生出 V2 .dat
+图片解密所需的 (xor_key, aes_key)。解决 issue #23：macOS 用户无法用
+C 版扫描器从进程内存提取图片密钥（197K 候选全部失败）。
+
+派生算法
+--------
+- 扫 ~/.../app_data/net/kvcomm/key_<code>_*.statistic 文件名
+- 对每个 (code, wxid) 候选：
+    xor_key = code & 0xFF
+    aes_key = MD5(str(code) + cleaned_wxid).hex()[:16]   # ASCII 字符串
+- 用 V2 _t.dat 文件 [0xF:0x1F] 16 字节做模板验证：派生出的 aes_key 把
+  密文 AES-128-ECB 解出图像 magic（JPEG / PNG / GIF / WebP / wxgf）即视为命中
+- 为防短 magic 偶然命中，要求多个不同模板都通过验证才视为成功
+- 命中后写回 config.json 的 image_aes_key / image_xor_key 字段，
+  monitor_web.py 启动时自动加载，图片消息显示内联预览
+
+致谢
+----
+派生算法源自 @hicccc77 在 issue #23 的评论，参考实现位于
+https://github.com/hicccc77/WeFlow （CC BY-NC-SA 4.0）。本模块是独立的
+Python 实现，未复制其 TypeScript 源码；函数边界与变量命名沿用算法的自然
+结构（regex 模式 / MD5 调用顺序 / magic 字节表等不可避免地相同）。
+
+用法
+----
+  python find_image_key_macos.py
+"""
+import glob
+import hashlib
+import json
+import os
+import platform
+import re
+import sys
+
+from Crypto.Cipher import AES
+
+# V2 .dat 文件 magic（与 decode_image.py 中 V2_MAGIC_FULL 一致）
+V2_MAGIC = bytes.fromhex("070856320807")
+
+# kvcomm 文件名格式：key_<code>_<其他段>.statistic
+# code 必须紧跟在 "key_" 之后（不能是 "key_reportnow_..." 这种带前缀的）
+_KVCOMM_FILENAME_RE = re.compile(r"^key_(\d+)_.+\.statistic$", re.IGNORECASE)
+
+# AES 解密结果允许的图像 magic
+_IMAGE_MAGICS = (
+    b"\xff\xd8\xff",      # JPEG
+    b"\x89\x50\x4e\x47",  # PNG
+    b"GIF",               # GIF
+    b"RIFF",              # WebP container（首块只能看前 16B，全检需 [8:12]==b"WEBP"）
+    b"wxgf",              # 微信 HEVC GIF / Live Photo
+)
+
+
+def normalize_wxid(account_id):
+    """归一化账号 ID。
+
+    - wxid_<seg> 形式：保留 wxid_<seg>，丢弃后续下划线分段
+    - <base>_<4 alnum> 形式：丢弃 _<4 alnum> 后缀（macOS 路径目录名常见）
+    - 其他：原样返回
+    """
+    aid = (account_id or "").strip()
+    if not aid:
+        return ""
+    if aid.lower().startswith("wxid_"):
+        m = re.match(r"^(wxid_[^_]+)", aid, re.IGNORECASE)
+        return m.group(1) if m else aid
+    m = re.match(r"^(.+)_([a-zA-Z0-9]{4})$", aid)
+    return m.group(1) if m else aid
+
+
+def derive_image_keys(code, wxid):
+    """从 (code, wxid) 派生 (xor_key, aes_key_ascii)。
+
+    aes_key_ascii 是 16 字符 hex 字符串；调用方按 ASCII 编码取前 16 字节作为
+    AES-128 密钥。本函数不做 wxid 归一化（由调用方枚举原值与归一化值）。
+    """
+    xor_key = int(code) & 0xFF
+    aes_key = hashlib.md5(f"{code}{wxid}".encode("utf-8")).hexdigest()[:16]
+    return xor_key, aes_key
+
+
+def derive_kvcomm_dir_candidates(db_dir):
+    """从 db_dir 推算所有可能的 kvcomm 缓存目录（按优先级排序）。
+
+    微信 4.x 在不同版本 / 安装方式下 kvcomm 路径不固定，需要枚举多个候选。
+    返回的列表里至少有一项被 os.path.isdir 确认存在时才算可用。
+    """
+    parts = db_dir.rstrip(os.sep).split(os.sep)
+    candidates = []
+    if "xwechat_files" in parts:
+        idx = parts.index("xwechat_files")
+        documents_root = os.sep.join(parts[:idx])
+        # 1) 与 xwechat_files 兄弟目录的 app_data
+        candidates.append(os.path.join(documents_root, "app_data", "net", "kvcomm"))
+        # 2) 旧版可能放 xwechat 子目录
+        candidates.append(os.path.join(documents_root, "xwechat", "net", "kvcomm"))
+        # 3) 容器内 Application Support 路径（部分版本）
+        if idx >= 1:
+            container_root = os.sep.join(parts[:idx - 1])  # Documents 之上
+            candidates.append(os.path.join(
+                container_root, "Library", "Application Support",
+                "com.tencent.xinWeChat", "xwechat", "net", "kvcomm"))
+            candidates.append(os.path.join(
+                container_root, "Library", "Application Support",
+                "com.tencent.xinWeChat", "net", "kvcomm"))
+    # 4) 兜底：HOME 下默认沙盒路径
+    home = os.path.expanduser("~")
+    candidates.append(os.path.join(
+        home, "Library", "Containers", "com.tencent.xinWeChat", "Data",
+        "Documents", "app_data", "net", "kvcomm"))
+    # 去重，保留顺序
+    seen = set()
+    deduped = []
+    for c in candidates:
+        if c not in seen:
+            seen.add(c)
+            deduped.append(c)
+    return deduped
+
+
+def find_existing_kvcomm_dir(db_dir):
+    """从候选路径中返回第一个存在的 kvcomm 目录；都不存在返回 None。"""
+    for candidate in derive_kvcomm_dir_candidates(db_dir):
+        if os.path.isdir(candidate):
+            return candidate
+    return None
+
+
+def collect_kvcomm_codes(kvcomm_dir):
+    """扫 kvcomm 目录，返回去重排序的 code 列表。"""
+    if not kvcomm_dir or not os.path.isdir(kvcomm_dir):
+        return []
+    codes = set()
+    try:
+        names = os.listdir(kvcomm_dir)
+    except OSError:
+        return []
+    for name in names:
+        m = _KVCOMM_FILENAME_RE.match(name)
+        if not m:
+            continue
+        try:
+            code = int(m.group(1))
+        except ValueError:
+            continue
+        if 0 < code <= 0xFFFFFFFF:
+            codes.add(code)
+    return sorted(codes)
+
+
+def collect_wxid_candidates(db_dir):
+    """从 db_dir 提取候选 wxid（含原值和归一化值）。"""
+    parts = db_dir.rstrip(os.sep).split(os.sep)
+    if "xwechat_files" not in parts:
+        return []
+    idx = parts.index("xwechat_files")
+    if idx + 1 >= len(parts):
+        return []
+    raw = parts[idx + 1]
+    candidates = [raw]
+    normalized = normalize_wxid(raw)
+    if normalized and normalized != raw:
+        candidates.append(normalized)
+    return candidates
+
+
+def find_v2_template_ciphertexts(attach_dir, max_templates=3, max_files=64):
+    """在 attach_dir 下找 V2 .dat 文件的模板密文（[0xF:0x1F] 16 字节）。
+
+    优先 _t.dat（缩略图小、读得快），找不到再降级用任意 .dat。
+    返回最多 max_templates 个**不同**的密文，用于交叉验证防止短 magic 偶然命中。
+    """
+    if not attach_dir or not os.path.isdir(attach_dir):
+        return []
+
+    def _scan(suffix):
+        # 出口条件只看是否凑够 max_templates 个**不同**密文；不因为
+        # examined 达到 max_files 提前退出 —— 否则若前 64 个文件都是同一
+        # 张图的副本，结果只有 1 个 template，交叉验证就退化成单模板。
+        out, seen = [], set()
+        examined = 0
+        for root, _, files in os.walk(attach_dir):
+            for f in files:
+                if not f.endswith(suffix):
+                    continue
+                examined += 1
+                try:
+                    with open(os.path.join(root, f), "rb") as fp:
+                        data = fp.read(0x20)
+                except OSError:
+                    continue
+                if len(data) >= 0x1F and data[:6] == V2_MAGIC:
+                    ct = data[0xF:0x1F]
+                    if ct not in seen:
+                        seen.add(ct)
+                        out.append(ct)
+                        if len(out) >= max_templates:
+                            return out
+                # 兜底：扫了 max_files 个文件还凑不齐 max_templates 个不同的，
+                # 提前停止以免在巨型 attach 目录里跑很久（只在 out 不空时才能停）
+                if examined >= max_files and out:
+                    return out
+        return out
+
+    return _scan("_t.dat") or _scan(".dat")
+
+
+def verify_aes_key(aes_key_ascii, template_ct):
+    """AES-128-ECB 解 template_ct（16 字节），检查头部是否是图像 magic。"""
+    if not aes_key_ascii or not template_ct or len(template_ct) != 16:
+        return False
+    key_bytes = aes_key_ascii.encode("ascii", errors="ignore")[:16]
+    if len(key_bytes) < 16:
+        return False
+    try:
+        cipher = AES.new(key_bytes, AES.MODE_ECB)
+        decrypted = cipher.decrypt(template_ct)
+    except (ValueError, KeyError):
+        return False
+    return any(decrypted.startswith(m) for m in _IMAGE_MAGICS)
+
+
+def verify_aes_key_against_all(aes_key_ascii, templates):
+    """在多个模板上交叉验证 aes_key。全部通过才算命中（防短 magic 偶然碰撞）。"""
+    if not templates:
+        return False
+    return all(verify_aes_key(aes_key_ascii, ct) for ct in templates)
+
+
+def find_image_key_macos(db_dir):
+    """在 macOS 上派生并交叉验证 V2 图片密钥。
+
+    Returns:
+        (xor_key, aes_key_ascii) on success；失败返回 None 并打印诊断信息。
+    """
+    kvcomm_dir = find_existing_kvcomm_dir(db_dir)
+    if not kvcomm_dir:
+        print(f"[!] 找不到 kvcomm 缓存目录，已尝试以下候选:", flush=True)
+        for c in derive_kvcomm_dir_candidates(db_dir):
+            print(f"      {c}", flush=True)
+        print("    通常意味着微信尚未生成密钥缓存，请先在微信中查看 1-2 张图片",
+              flush=True)
+        return None
+    print(f"[+] 使用 kvcomm 目录: {kvcomm_dir}", flush=True)
+
+    codes = collect_kvcomm_codes(kvcomm_dir)
+    if not codes:
+        print(f"[!] kvcomm 目录无 key_*.statistic 文件: {kvcomm_dir}", flush=True)
+        return None
+    print(f"[+] 找到 {len(codes)} 个 code 候选", flush=True)
+
+    wxid_candidates = collect_wxid_candidates(db_dir)
+    if not wxid_candidates:
+        print(f"[!] 无法从 db_dir 提取 wxid: {db_dir}", flush=True)
+        return None
+    print(f"[+] wxid 候选: {wxid_candidates}", flush=True)
+
+    base_dir = os.path.dirname(db_dir)  # 去掉 db_storage
+    attach_dir = os.path.join(base_dir, "msg", "attach")
+    templates = find_v2_template_ciphertexts(attach_dir)
+    if not templates:
+        print(f"[!] 在 {attach_dir} 下找不到 V2 模板文件", flush=True)
+        print("    请先在微信中查看 1-2 张图片，让微信生成 V2 .dat 文件",
+              flush=True)
+        return None
+    print(f"[+] 找到 {len(templates)} 个不同模板用于交叉验证", flush=True)
+
+    # 穷举顺序：wxid 外、code 内。这样多账号系统下当前账号的所有 code 优先尝试。
+    for wxid in wxid_candidates:
+        for code in codes:
+            xor_key, aes_key = derive_image_keys(code, wxid)
+            if verify_aes_key_against_all(aes_key, templates):
+                print()
+                print("[✓] 验证成功（所有模板均通过）:", flush=True)
+                print(f"    code     = {code}", flush=True)
+                print(f"    wxid     = {wxid}", flush=True)
+                print(f"    xor_key  = 0x{xor_key:02x}", flush=True)
+                print(f"    aes_key  = {aes_key}", flush=True)
+                return xor_key, aes_key
+
+    print()
+    print("[!] 所有 (wxid × code) 组合都未通过交叉验证", flush=True)
+    print("    可能原因：微信版本变更了派生算法 / 缓存已失效 / 模板文件损坏",
+          flush=True)
+    return None
+
+
+def _save_config_atomic(config_path, config):
+    """原子写 config.json：tmp + os.replace 防止中断留下半截文件。
+
+    若 json.dump 或 os.replace 抛错，向上抛出（让 main 给出 stacktrace
+    而不是默默写坏 config）；同时清理可能残留的 .tmp 文件。
+    """
+    tmp_path = config_path + ".tmp"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, config_path)
+    finally:
+        # 失败路径上 .tmp 可能残留；成功路径上 os.replace 已经把 tmp 移走了
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def main(config_path=None):
+    """CLI 入口。`config_path` 默认是脚本同目录下的 config.json，
+    暴露此参数主要为方便单元测试注入隔离的临时配置。"""
+    if platform.system().lower() != "darwin":
+        print("此脚本只在 macOS 上工作。其他平台请用 find_image_key.py（内存扫描）。",
+              file=sys.stderr, flush=True)
+        sys.exit(1)
+
+    if config_path is None:
+        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                   "config.json")
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            config = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"[!] 读取 {config_path} 失败: {e}", file=sys.stderr, flush=True)
+        sys.exit(1)
+
+    db_dir = config.get("db_dir", "")
+    if not db_dir:
+        print("[!] config.json 中未配置 db_dir", file=sys.stderr, flush=True)
+        sys.exit(1)
+    print(f"[*] db_dir = {db_dir}", flush=True)
+
+    # 短路：如果已有 image_aes_key 且仍能在所有模板上验证通过，直接退出
+    # （沿用 find_image_key.py 的 UX 约定，避免无谓重写 config.json）
+    existing_aes = config.get("image_aes_key")
+    if existing_aes:
+        base_dir = os.path.dirname(db_dir)
+        attach_dir = os.path.join(base_dir, "msg", "attach")
+        templates = find_v2_template_ciphertexts(attach_dir)
+        if templates and verify_aes_key_against_all(existing_aes, templates):
+            print(f"[+] 已有 image_aes_key={existing_aes} 在 "
+                  f"{len(templates)} 个模板上仍然有效，无需重新派生", flush=True)
+            return
+
+    result = find_image_key_macos(db_dir)
+    if result is None:
+        sys.exit(1)
+
+    xor_key, aes_key = result
+    config["image_aes_key"] = aes_key
+    config["image_xor_key"] = xor_key
+    _save_config_atomic(config_path, config)
+    print()
+    print(f"[+] 已写入 {config_path}", flush=True)
+    print("    下次启动 monitor_web.py 时会自动加载新密钥，图片消息显示内联预览",
+          flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/find_image_key_macos.py
+++ b/find_image_key_macos.py
@@ -45,10 +45,13 @@ uin 来源（两条路径，dispatcher 自动 fallback）
 """
 import hashlib
 import json
+import multiprocessing
 import os
 import platform
+import queue as _queue
 import re
 import sys
+import time
 from collections import Counter
 
 from Crypto.Cipher import AES
@@ -324,6 +327,10 @@ def bruteforce_uin_candidates(xor_key, wxid_suffix):
 
     注意 uin 上限假设为 2^32（4 字节无符号整数）。函数命名沿用密码学
     候选搜索的 brute-force 术语；中文 prose 用 "枚举 / 候选搜索" 表述。
+
+    本函数是单进程 + hex 比较版本, 主要用作算法金标准 (测试) 与
+    parallel 路径不可用时的 fallback。生产 dispatcher 走 parallel
+    版本 (见 `_bruteforce_with_aes_parallel`)。
     """
     target = wxid_suffix.lower()
     out = []
@@ -331,6 +338,97 @@ def bruteforce_uin_candidates(xor_key, wxid_suffix):
         if hashlib.md5(str(uin).encode()).hexdigest()[:4] == target:
             out.append(uin)
     return out
+
+
+def _aes_template_match(aes_bytes, ciphertext):
+    """worker 进程内: AES-128-ECB 解 ciphertext 并检查图像 magic。
+
+    放模块顶层是为了 multiprocessing pickle (worker 函数必须可 import).
+    比 verify_aes_key 更紧凑 (省去 try-except 默认通过短路) — 在百万次
+    调用循环里这点开销有意义。
+    """
+    try:
+        decrypted = AES.new(aes_bytes, AES.MODE_ECB).decrypt(ciphertext)
+    except (ValueError, KeyError):
+        return False
+    return any(decrypted.startswith(m) for m in _IMAGE_MAGICS)
+
+
+def _bruteforce_worker_chunk(start, end, xor_key, suffix_bytes, wxid_bytes,
+                              templates, result_queue):
+    """worker: 扫候选区间, 命中 (md5 前缀 + 全模板 AES) 推入 queue 即返回。
+
+    内联做 md5 + AES 验证 (不分两 pass) 让早停在 worker 内有效。
+    suffix 用 binary 比 (digest()[:2] vs hexdigest()[:4]), 节省 hex 转换。
+    """
+    for i in range(start, end):
+        uin = (i << 8) | xor_key
+        uin_bytes = str(uin).encode("ascii")
+        if hashlib.md5(uin_bytes).digest()[:2] == suffix_bytes:
+            aes_hex = hashlib.md5(uin_bytes + wxid_bytes).hexdigest()[:16]
+            aes_bytes = aes_hex.encode("ascii")
+            if all(_aes_template_match(aes_bytes, ct) for ct in templates):
+                result_queue.put((uin, aes_hex))
+                return
+
+
+def _bruteforce_with_aes_parallel(xor_key, suffix_hex, wxid_norm, templates,
+                                   workers=None, timeout=60):
+    """方案2 多进程实现 — 加速思路借鉴自 @H3CoF6 PR #69.
+
+    与单进程版本的差异:
+    - cpu_count 个 worker 并行扫 0~2^32 候选 (~5-8x 加速)
+    - 二进制 md5 digest()[:2] 替代 hexdigest()[:4] (省 hex 转换)
+    - 内联多模板 AES 验证 (无两 pass; PR #69 是单模板, 本实现保留多模板
+      交叉验证防短 magic 偶然命中)
+    - 任一 worker 命中即推 queue, 主进程 terminate 其他 (早停)
+
+    Returns:
+        (uin, aes_key_hex) 或 None (timeout / 全 worker 跑完未命中)
+    """
+    suffix_bytes = bytes.fromhex(suffix_hex)
+    wxid_bytes = wxid_norm.encode("ascii")
+    if workers is None:
+        workers = max(1, multiprocessing.cpu_count())
+    total = 1 << 24
+    chunk = total // workers
+
+    queue = multiprocessing.Queue()
+    procs = []
+    for i in range(workers):
+        start_i = i * chunk
+        end_i = (i + 1) * chunk if i != workers - 1 else total
+        p = multiprocessing.Process(
+            target=_bruteforce_worker_chunk,
+            args=(start_i, end_i, xor_key, suffix_bytes, wxid_bytes,
+                  templates, queue),
+            daemon=True,
+        )
+        p.start()
+        procs.append(p)
+
+    found = None
+    deadline = time.time() + timeout
+    try:
+        while any(p.is_alive() for p in procs) and time.time() < deadline:
+            try:
+                found = queue.get(timeout=0.1)
+                break
+            except _queue.Empty:
+                continue
+        # 所有 worker 死亡后 queue 仍可能有最后入队的数据
+        if not found:
+            try:
+                found = queue.get_nowait()
+            except _queue.Empty:
+                pass
+    finally:
+        for p in procs:
+            if p.is_alive():
+                p.terminate()
+        for p in procs:
+            p.join(timeout=1)
+    return found
 
 
 # ---------- Dispatcher + 两条路径 ---------- #
@@ -405,27 +503,35 @@ def _find_via_bruteforce(db_dir, attach_dir, templates):
         print(f"[!] 方案2: xor_key 投票分歧 {votes}/{total}, 取多数 0x{xor_key:02x} "
               f"(可能 attach 不全是 JPG)", flush=True)
 
-    print("[*] 方案2: 枚举 2^24 候选 (预计 5-10 秒)...", flush=True)
-    candidates = bruteforce_uin_candidates(xor_key, suffix)
-    print(f"[+] 方案2: {len(candidates)} 个 uin 候选, 跑 AES 验证", flush=True)
+    workers = max(1, multiprocessing.cpu_count())
+    print(f"[*] 方案2: 多进程枚举 (workers={workers}, 预计 ~1-2 秒)...",
+          flush=True)
 
     # 同时试 wxid_full 和 wxid_norm（normalize_wxid 可能去掉后缀）
     wxid_tries = [wxid_norm]
     if wxid_full != wxid_norm:
         wxid_tries.append(wxid_full)
-    for wxid_try in wxid_tries:
-        for uin in candidates:
-            _, aes_key = derive_image_keys(uin, wxid_try)
-            if verify_aes_key_against_all(aes_key, templates):
-                print()
-                print("[OK] 方案2 (fallback) 验证成功:", flush=True)
-                print(f"    uin      = {uin}", flush=True)
-                print(f"    wxid     = {wxid_try}", flush=True)
-                print(f"    xor_key  = 0x{xor_key:02x}", flush=True)
-                print(f"    aes_key  = {aes_key}", flush=True)
-                return xor_key, aes_key
 
-    print("[!] 方案2: 所有 uin 候选都未通过 AES 验证", flush=True)
+    t0 = time.time()
+    for wxid_try in wxid_tries:
+        result = _bruteforce_with_aes_parallel(
+            xor_key, suffix, wxid_try, templates, workers=workers
+        )
+        if result:
+            uin, aes_key = result
+            elapsed = time.time() - t0
+            print()
+            print(f"[OK] 方案2 (fallback) 验证成功 (耗时 {elapsed:.1f}s):",
+                  flush=True)
+            print(f"    uin      = {uin}", flush=True)
+            print(f"    wxid     = {wxid_try}", flush=True)
+            print(f"    xor_key  = 0x{xor_key:02x}", flush=True)
+            print(f"    aes_key  = {aes_key}", flush=True)
+            return xor_key, aes_key
+
+    elapsed = time.time() - t0
+    print(f"[!] 方案2: 所有 uin 候选都未通过 AES 验证 (耗时 {elapsed:.1f}s)",
+          flush=True)
     return None
 
 

--- a/find_image_key_macos.py
+++ b/find_image_key_macos.py
@@ -257,7 +257,7 @@ def extract_wxid_parts(db_dir):
     """从 db_dir 提取 (wxid_full, wxid_norm, suffix)。
 
     db_dir 形如 .../xwechat_files/<wxid>_<4hex>/db_storage
-    返回 ('A_Hare_626a', 'A_Hare', '626a') 或 None（不匹配 _<4 hex> 后缀）。
+    返回 ('your_wxid_a1b2', 'your_wxid', 'a1b2') 或 None（不匹配 _<4 hex> 后缀）。
 
     suffix 是 4 位小写 hex（macOS 路径目录名固定格式 = md5(str(uin))[:4]），
     用作方案2 中候选搜索的 md5 前缀目标。

--- a/find_image_key_macos.py
+++ b/find_image_key_macos.py
@@ -1,39 +1,55 @@
-"""macOS WeChat 4.x 图片 AES key 派生（无需扫描进程内存）。
+"""macOS WeChat 4.x 图片 AES key 派生（无需读运行进程）。
 
-通过 macOS 微信 4.x 在磁盘上的 kvcomm 缓存文件命名约定，派生出 V2 .dat
-图片解密所需的 (xor_key, aes_key)。解决 issue #23：macOS 用户无法用
-C 版扫描器从进程内存提取图片密钥（197K 候选全部失败）。
+通过 macOS 微信 4.x 在磁盘上的命名约定派生出 V2 .dat 图片解密所需的
+(xor_key, aes_key)。解决 issue #23：macOS 用户无法用 C 版扫描器从运行
+进程读取出有效的访问凭据（197K 候选全部失败）。
 
-派生算法
---------
-- 扫 ~/.../app_data/net/kvcomm/key_<code>_*.statistic 文件名
-- 对每个 (code, wxid) 候选：
-    xor_key = code & 0xFF
-    aes_key = MD5(str(code) + cleaned_wxid).hex()[:16]   # ASCII 字符串
+派生算法（共享核心）
+--------------------
+- xor_key = uin & 0xFF
+- aes_key = MD5(str(uin) + cleaned_wxid).hex()[:16]   # ASCII 字符串
 - 用 V2 _t.dat 文件 [0xF:0x1F] 16 字节做模板验证：派生出的 aes_key 把
   密文 AES-128-ECB 解出图像 magic（JPEG / PNG / GIF / WebP / wxgf）即视为命中
 - 为防短 magic 偶然命中，要求多个不同模板都通过验证才视为成功
-- 命中后写回 config.json 的 image_aes_key / image_xor_key 字段，
-  monitor_web.py 启动时自动加载，图片消息显示内联预览
+
+uin 来源（两条路径，dispatcher 自动 fallback）
+----------------------------------------------
+方案1（kvcomm 缓存文件名，主路径）：
+  读 ~/.../app_data/net/kvcomm/key_<uin>_*.statistic 提 uin。
+  优点：~毫秒级；缺点：依赖缓存文件，多账号下可能歧义。
+
+方案2（wxid 后缀候选搜索，fallback 路径）：
+  关键洞察：wxid 目录后 4 位 hex == md5(str(uin))[:4]。
+  流程：从 V2 .dat 末字节投票反推 xor_key (假设 JPG EOI = 0xD9) →
+  枚举 (uin & 0xff == xor_key) 的 2^24 个候选 → md5 前缀匹配
+  得 ~256 个 uin 候选 → AES 模板验证唯一定位。
+  优点：不依赖 kvcomm，多账号无歧义；缺点：~7 秒（单核 2^24 MD5）。
+
+命中后写回 config.json 的 image_aes_key / image_xor_key，monitor_web.py
+启动时自动加载，图片消息显示内联预览。
 
 致谢
 ----
-派生算法源自 @hicccc77 在 issue #23 的评论，参考实现位于
-https://github.com/hicccc77/WeFlow （CC BY-NC-SA 4.0）。本模块是独立的
-Python 实现，未复制其 TypeScript 源码；函数边界与变量命名沿用算法的自然
-结构（regex 模式 / MD5 调用顺序 / magic 字节表等不可避免地相同）。
+- 方案1（kvcomm 派生）算法源自 @hicccc77 在 issue #23 的评论，参考实现
+  位于 https://github.com/hicccc77/WeFlow （CC BY-NC-SA 4.0）。
+- 方案2（wxid 后缀候选搜索）思路源自 @H3CoF6 在 issue #68 的评论，
+  提供了 "wxid 后 4 位 == md5(uin)[:4]" 这一关键结构性洞察。
+
+本模块是独立的 Python 实现，未复制任何上游 TypeScript / C 源码；函数
+边界与变量命名沿用算法的自然结构（regex / MD5 调用顺序 / magic 字节表
+等不可避免地相同）。
 
 用法
 ----
   python find_image_key_macos.py
 """
-import glob
 import hashlib
 import json
 import os
 import platform
 import re
 import sys
+from collections import Counter
 
 from Crypto.Cipher import AES
 
@@ -230,34 +246,198 @@ def verify_aes_key_against_all(aes_key_ascii, templates):
     return all(verify_aes_key(aes_key_ascii, ct) for ct in templates)
 
 
+# ---------- 方案2 (wxid 后缀候选搜索, fallback) ---------- #
+
+# md5 hex 后缀只可能是 [0-9a-f]; 严格匹配避免误吃非 hex 字符的 wxid 后缀
+# (microsoft 改方案 / 异常路径) 后悄悄返回空候选误导用户。
+_WXID_HEX_SUFFIX_RE = re.compile(r"^(.+)_([0-9a-fA-F]{4})$")
+
+
+def extract_wxid_parts(db_dir):
+    """从 db_dir 提取 (wxid_full, wxid_norm, suffix)。
+
+    db_dir 形如 .../xwechat_files/<wxid>_<4hex>/db_storage
+    返回 ('A_Hare_626a', 'A_Hare', '626a') 或 None（不匹配 _<4 hex> 后缀）。
+
+    suffix 是 4 位小写 hex（macOS 路径目录名固定格式 = md5(str(uin))[:4]），
+    用作方案2 中候选搜索的 md5 前缀目标。
+    """
+    wxid_candidates = collect_wxid_candidates(db_dir)
+    if not wxid_candidates:
+        return None
+    wxid_full = wxid_candidates[0]  # raw 总是第一个
+    m = _WXID_HEX_SUFFIX_RE.match(wxid_full)
+    if not m:
+        return None
+    return wxid_full, m.group(1), m.group(2).lower()
+
+
+def derive_xor_key_from_v2_dat(attach_dir, sample=10, min_samples=3):
+    """扫多个 V2 .dat 末字节投票反推 xor_key（假设 JPG EOI = 0xD9）。
+
+    macOS 缩略图 _t.dat 几乎都是 JPG，末字节 = 0xD9 ^ xor_key 反推稳定。
+    投票多数一致才信；分歧大说明假设破灭（不全是 JPG）。
+
+    Args:
+        attach_dir: 微信 attach 目录
+        sample: 扫到 N 个 V2 .dat 即停止（性能上限）
+        min_samples: 至少 N 个样本才视为"投票可信"。低于此返回 None,
+            避免 1-2 个样本时一旦撞到非 JPG 就 lock 错 xor_key。
+    Returns:
+        (xor_key, votes, total) 或 None (样本不足 / 找不到 V2 .dat)。
+        votes < total 时调用方应警告 (假设可能破灭)。
+    """
+    if not attach_dir or not os.path.isdir(attach_dir):
+        return None
+    last_bytes = []
+    for root, _, files in os.walk(attach_dir):
+        for f in files:
+            if not f.endswith(".dat"):
+                continue
+            path = os.path.join(root, f)
+            try:
+                if os.path.getsize(path) < 0x20:
+                    continue
+                with open(path, "rb") as fp:
+                    head = fp.read(6)
+                    if head != V2_MAGIC:
+                        continue
+                    fp.seek(-1, 2)
+                    last = fp.read(1)[0]
+                last_bytes.append(last ^ 0xD9)
+                if len(last_bytes) >= sample:
+                    break
+            except OSError:
+                continue
+        if len(last_bytes) >= sample:
+            break
+    if len(last_bytes) < min_samples:
+        return None
+    top, votes = Counter(last_bytes).most_common(1)[0]
+    return top, votes, len(last_bytes)
+
+
+def bruteforce_uin_candidates(xor_key, wxid_suffix):
+    """枚举 0~2^32 中 (uin & 0xff == xor_key) 且 md5(str(uin))[:4] == suffix 的 uin。
+
+    单核 ~7-8 秒（2^24 = 16M MD5）。期望命中数 ~256（2^24 / 16^4）。
+
+    注意 uin 上限假设为 2^32（4 字节无符号整数）。函数命名沿用密码学
+    候选搜索的 brute-force 术语；中文 prose 用 "枚举 / 候选搜索" 表述。
+    """
+    target = wxid_suffix.lower()
+    out = []
+    for uin in range(xor_key, 2 ** 32, 256):
+        if hashlib.md5(str(uin).encode()).hexdigest()[:4] == target:
+            out.append(uin)
+    return out
+
+
+# ---------- Dispatcher + 两条路径 ---------- #
+
+def _find_via_kvcomm(db_dir, templates):
+    """方案1：从 kvcomm 缓存文件名提 uin 候选。
+
+    要求：~/.../app_data/net/kvcomm/key_<uin>_*.statistic 存在。
+    返回 (xor_key, aes_key) 或 None（kvcomm 缺失 / 无 code / wxid 提不出 /
+    所有组合都验证失败）。
+    """
+    kvcomm_dir = find_existing_kvcomm_dir(db_dir)
+    if not kvcomm_dir:
+        print("[!] 方案1: 找不到 kvcomm 缓存目录，已尝试以下候选:", flush=True)
+        for c in derive_kvcomm_dir_candidates(db_dir):
+            print(f"      {c}", flush=True)
+        return None
+    print(f"[+] 方案1: 使用 kvcomm 目录 {kvcomm_dir}", flush=True)
+
+    codes = collect_kvcomm_codes(kvcomm_dir)
+    if not codes:
+        print("[!] 方案1: kvcomm 目录无 key_*.statistic 文件", flush=True)
+        return None
+    print(f"[+] 方案1: 找到 {len(codes)} 个 uin 候选", flush=True)
+
+    wxid_candidates = collect_wxid_candidates(db_dir)
+    if not wxid_candidates:
+        print("[!] 方案1: 无法从 db_dir 提取 wxid", flush=True)
+        return None
+    print(f"[+] 方案1: wxid 候选 {wxid_candidates}", flush=True)
+
+    # 穷举顺序：wxid 外、uin 内。多账号系统下当前账号的所有 uin 优先尝试。
+    for wxid in wxid_candidates:
+        for code in codes:
+            xor_key, aes_key = derive_image_keys(code, wxid)
+            if verify_aes_key_against_all(aes_key, templates):
+                print()
+                print("[OK] 方案1 验证成功（所有模板均通过）:", flush=True)
+                print(f"    uin      = {code}", flush=True)
+                print(f"    wxid     = {wxid}", flush=True)
+                print(f"    xor_key  = 0x{xor_key:02x}", flush=True)
+                print(f"    aes_key  = {aes_key}", flush=True)
+                return xor_key, aes_key
+
+    print("[!] 方案1: 所有 (wxid × uin) 组合都未通过交叉验证", flush=True)
+    return None
+
+
+def _find_via_bruteforce(db_dir, attach_dir, templates):
+    """方案2 (fallback)：从 wxid 后缀候选搜索 uin（不依赖 kvcomm）。
+
+    流程：wxid 后缀 + V2 .dat 末字节投票反推 xor_key → 枚举 2^24 个 uin
+    候选 → 用 templates 跑 AES 验证唯一定位。
+    """
+    parts = extract_wxid_parts(db_dir)
+    if not parts:
+        print("[!] 方案2: wxid 路径不含 _<4 hex> 后缀，无法应用方案2", flush=True)
+        return None
+    wxid_full, wxid_norm, suffix = parts
+    print(f"[+] 方案2: wxid_full={wxid_full}, suffix={suffix}", flush=True)
+
+    xres = derive_xor_key_from_v2_dat(attach_dir)
+    if not xres:
+        print("[!] 方案2: V2 .dat 样本不足 (需 >= 3 个), 无法投票反推 xor_key",
+              flush=True)
+        return None
+    xor_key, votes, total = xres
+    if votes == total:
+        print(f"[+] 方案2: xor_key=0x{xor_key:02x} ({votes}/{total} 一致, 假设 JPG)",
+              flush=True)
+    else:
+        print(f"[!] 方案2: xor_key 投票分歧 {votes}/{total}, 取多数 0x{xor_key:02x} "
+              f"(可能 attach 不全是 JPG)", flush=True)
+
+    print("[*] 方案2: 枚举 2^24 候选 (预计 5-10 秒)...", flush=True)
+    candidates = bruteforce_uin_candidates(xor_key, suffix)
+    print(f"[+] 方案2: {len(candidates)} 个 uin 候选, 跑 AES 验证", flush=True)
+
+    # 同时试 wxid_full 和 wxid_norm（normalize_wxid 可能去掉后缀）
+    wxid_tries = [wxid_norm]
+    if wxid_full != wxid_norm:
+        wxid_tries.append(wxid_full)
+    for wxid_try in wxid_tries:
+        for uin in candidates:
+            _, aes_key = derive_image_keys(uin, wxid_try)
+            if verify_aes_key_against_all(aes_key, templates):
+                print()
+                print("[OK] 方案2 (fallback) 验证成功:", flush=True)
+                print(f"    uin      = {uin}", flush=True)
+                print(f"    wxid     = {wxid_try}", flush=True)
+                print(f"    xor_key  = 0x{xor_key:02x}", flush=True)
+                print(f"    aes_key  = {aes_key}", flush=True)
+                return xor_key, aes_key
+
+    print("[!] 方案2: 所有 uin 候选都未通过 AES 验证", flush=True)
+    return None
+
+
 def find_image_key_macos(db_dir):
     """在 macOS 上派生并交叉验证 V2 图片密钥。
+
+    Dispatcher：先尝试方案1 (kvcomm)，失败 fallback 到方案2 (候选搜索)。
+    两条路径都需要 V2 .dat 模板做 AES 验证 — 模板缺失就直接失败。
 
     Returns:
         (xor_key, aes_key_ascii) on success；失败返回 None 并打印诊断信息。
     """
-    kvcomm_dir = find_existing_kvcomm_dir(db_dir)
-    if not kvcomm_dir:
-        print(f"[!] 找不到 kvcomm 缓存目录，已尝试以下候选:", flush=True)
-        for c in derive_kvcomm_dir_candidates(db_dir):
-            print(f"      {c}", flush=True)
-        print("    通常意味着微信尚未生成密钥缓存，请先在微信中查看 1-2 张图片",
-              flush=True)
-        return None
-    print(f"[+] 使用 kvcomm 目录: {kvcomm_dir}", flush=True)
-
-    codes = collect_kvcomm_codes(kvcomm_dir)
-    if not codes:
-        print(f"[!] kvcomm 目录无 key_*.statistic 文件: {kvcomm_dir}", flush=True)
-        return None
-    print(f"[+] 找到 {len(codes)} 个 code 候选", flush=True)
-
-    wxid_candidates = collect_wxid_candidates(db_dir)
-    if not wxid_candidates:
-        print(f"[!] 无法从 db_dir 提取 wxid: {db_dir}", flush=True)
-        return None
-    print(f"[+] wxid 候选: {wxid_candidates}", flush=True)
-
     base_dir = os.path.dirname(db_dir)  # 去掉 db_storage
     attach_dir = os.path.join(base_dir, "msg", "attach")
     templates = find_v2_template_ciphertexts(attach_dir)
@@ -268,24 +448,15 @@ def find_image_key_macos(db_dir):
         return None
     print(f"[+] 找到 {len(templates)} 个不同模板用于交叉验证", flush=True)
 
-    # 穷举顺序：wxid 外、code 内。这样多账号系统下当前账号的所有 code 优先尝试。
-    for wxid in wxid_candidates:
-        for code in codes:
-            xor_key, aes_key = derive_image_keys(code, wxid)
-            if verify_aes_key_against_all(aes_key, templates):
-                print()
-                print("[✓] 验证成功（所有模板均通过）:", flush=True)
-                print(f"    code     = {code}", flush=True)
-                print(f"    wxid     = {wxid}", flush=True)
-                print(f"    xor_key  = 0x{xor_key:02x}", flush=True)
-                print(f"    aes_key  = {aes_key}", flush=True)
-                return xor_key, aes_key
+    # 方案1 (主路径): kvcomm 缓存
+    result = _find_via_kvcomm(db_dir, templates)
+    if result is not None:
+        return result
 
+    # 方案2 (fallback): wxid 后缀候选搜索
     print()
-    print("[!] 所有 (wxid × code) 组合都未通过交叉验证", flush=True)
-    print("    可能原因：微信版本变更了派生算法 / 缓存已失效 / 模板文件损坏",
-          flush=True)
-    return None
+    print("[*] 方案1 失败, 尝试方案2 (wxid 后缀候选搜索, fallback)", flush=True)
+    return _find_via_bruteforce(db_dir, attach_dir, templates)
 
 
 def _save_config_atomic(config_path, config):

--- a/tests/test_find_image_key_macos.py
+++ b/tests/test_find_image_key_macos.py
@@ -1,0 +1,488 @@
+"""单元测试：find_image_key_macos 派生算法 + 端到端 smoke。
+
+不依赖真实微信数据；用 tempdir + 合成密文构造测试。
+"""
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from Crypto.Cipher import AES
+
+import find_image_key_macos as fkm
+
+
+class NormalizeWxidTests(unittest.TestCase):
+    def test_wxid_with_extra_segments_keeps_only_first(self):
+        # wxid_<seg> 形式只保留第一段下划线之内的内容
+        self.assertEqual(fkm.normalize_wxid("wxid_abc123_extra_more"), "wxid_abc123")
+
+    def test_wxid_no_extra_segments(self):
+        self.assertEqual(fkm.normalize_wxid("wxid_abc123"), "wxid_abc123")
+
+    def test_account_with_4char_alnum_suffix_stripped(self):
+        # macOS 路径常见：your_wxid_a1b2c3 → your_wxid
+        self.assertEqual(fkm.normalize_wxid("your_wxid_a1b2c3"), "your_wxid")
+
+    def test_account_without_recognizable_suffix_returned_asis(self):
+        self.assertEqual(fkm.normalize_wxid("simple"), "simple")
+        self.assertEqual(fkm.normalize_wxid("foo_bar_baz"), "foo_bar_baz")  # baz 是 3 char
+
+    def test_empty_or_none_returns_empty(self):
+        self.assertEqual(fkm.normalize_wxid(""), "")
+        self.assertEqual(fkm.normalize_wxid(None), "")
+        self.assertEqual(fkm.normalize_wxid("   "), "")
+
+
+class DeriveImageKeysTests(unittest.TestCase):
+    def test_xor_is_low_byte_of_code(self):
+        xor, _ = fkm.derive_image_keys(0x12345678, "anything")
+        self.assertEqual(xor, 0x78)
+
+    def test_xor_handles_small_codes(self):
+        self.assertEqual(fkm.derive_image_keys(0xFF, "x")[0], 0xFF)
+        self.assertEqual(fkm.derive_image_keys(0x00, "x")[0], 0x00)
+
+    def test_aes_is_md5_hex_truncated_to_16(self):
+        # Golden value：来自 POC 在真实微信数据上的验证（issue #23 解的就是这一对）
+        xor, aes = fkm.derive_image_keys(18709375, "your_wxid")
+        self.assertEqual(xor, 0x7F)
+        self.assertEqual(aes, "b73bd4126969d30f")
+
+    def test_aes_does_not_normalize_wxid_internally(self):
+        # 归一化由调用方负责；不同 wxid 字符串产出不同 key
+        _, aes_full = fkm.derive_image_keys(18709375, "your_wxid_a1b2c3")
+        _, aes_norm = fkm.derive_image_keys(18709375, "your_wxid")
+        self.assertNotEqual(aes_full, aes_norm)
+
+
+class DeriveKvcommDirCandidatesTests(unittest.TestCase):
+    def test_canonical_macos_path_is_first_candidate(self):
+        db_dir = (
+            "/Users/x/Library/Containers/com.tencent.xinWeChat/Data/Documents/"
+            "xwechat_files/wxid_abc/db_storage"
+        )
+        candidates = fkm.derive_kvcomm_dir_candidates(db_dir)
+        self.assertGreater(len(candidates), 0)
+        expected_primary = (
+            "/Users/x/Library/Containers/com.tencent.xinWeChat/Data/Documents/"
+            "app_data/net/kvcomm"
+        )
+        self.assertEqual(candidates[0], expected_primary)
+
+    def test_returns_multiple_candidates(self):
+        # 多候选是 Round 1 review 的关键修复点：跨版本路径覆盖
+        db_dir = (
+            "/Users/x/Library/Containers/com.tencent.xinWeChat/Data/Documents/"
+            "xwechat_files/wxid_abc/db_storage"
+        )
+        candidates = fkm.derive_kvcomm_dir_candidates(db_dir)
+        self.assertGreaterEqual(len(candidates), 3,
+                                "应返回多个候选路径以覆盖不同微信版本布局")
+
+    def test_no_xwechat_files_still_returns_home_fallback(self):
+        # 即使无法从 db_dir 推算，也至少返回 HOME 默认路径作兜底
+        candidates = fkm.derive_kvcomm_dir_candidates("/random/path")
+        self.assertGreaterEqual(len(candidates), 1)
+        self.assertTrue(any("Containers/com.tencent.xinWeChat" in c
+                            for c in candidates))
+
+    def test_candidates_are_unique(self):
+        db_dir = "/x/y/Documents/xwechat_files/wxid_abc/db_storage"
+        candidates = fkm.derive_kvcomm_dir_candidates(db_dir)
+        self.assertEqual(len(candidates), len(set(candidates)))
+
+
+class FindExistingKvcommDirTests(unittest.TestCase):
+    def test_returns_first_existing_candidate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            # 构造合法 db_dir 路径，在第一个候选位置创建实际目录
+            base = os.path.join(tmp, "Documents", "xwechat_files", "wxid_x")
+            db_dir = os.path.join(base, "db_storage")
+            os.makedirs(db_dir)
+            kvcomm = os.path.join(tmp, "Documents", "app_data", "net", "kvcomm")
+            os.makedirs(kvcomm)
+
+            self.assertEqual(fkm.find_existing_kvcomm_dir(db_dir), kvcomm)
+
+    def test_returns_none_when_no_candidate_exists(self):
+        # 即使 HOME fallback 候选也不存在时，应返回 None。
+        # 隔离测试不能依赖宿主机有/无微信安装；patch expanduser 指向 tmp。
+        with tempfile.TemporaryDirectory() as fake_home:
+            with patch("os.path.expanduser", return_value=fake_home):
+                self.assertIsNone(fkm.find_existing_kvcomm_dir("/nonexistent/x/y/z"))
+
+
+class CollectKvcommCodesTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.kvdir = self._tmp.name
+
+    def _touch(self, name):
+        with open(os.path.join(self.kvdir, name), "w") as f:
+            f.write("")
+
+    def test_extracts_code_from_filename(self):
+        self._touch("key_18709375_4066645761_1_1777096531_137785059_3600_input.statistic")
+        self._touch("key_99999999_yyy_zzz.statistic")
+        self.assertEqual(fkm.collect_kvcomm_codes(self.kvdir), [18709375, 99999999])
+
+    def test_ignores_files_with_non_numeric_first_segment(self):
+        self._touch("key_reportnow_18709375_xxx.statistic")
+        self._touch("key_abc_def.statistic")
+        self._touch("config.ini")
+        self._touch("monitordata_x")
+        self.assertEqual(fkm.collect_kvcomm_codes(self.kvdir), [])
+
+    def test_dedupes_same_code_across_files(self):
+        self._touch("key_42_a.statistic")
+        self._touch("key_42_b.statistic")
+        self.assertEqual(fkm.collect_kvcomm_codes(self.kvdir), [42])
+
+    def test_missing_dir_returns_empty(self):
+        self.assertEqual(fkm.collect_kvcomm_codes("/nonexistent/xxx"), [])
+
+    def test_none_dir_returns_empty(self):
+        self.assertEqual(fkm.collect_kvcomm_codes(None), [])
+
+
+class CollectWxidCandidatesTests(unittest.TestCase):
+    def test_returns_raw_and_normalized_when_different(self):
+        db_dir = "/x/Documents/xwechat_files/your_wxid_a1b2c3/db_storage"
+        self.assertEqual(fkm.collect_wxid_candidates(db_dir),
+                         ["your_wxid_a1b2c3", "your_wxid"])
+
+    def test_returns_one_when_normalize_is_identity(self):
+        db_dir = "/x/Documents/xwechat_files/wxid_abc/db_storage"
+        self.assertEqual(fkm.collect_wxid_candidates(db_dir), ["wxid_abc"])
+
+    def test_no_xwechat_files_returns_empty(self):
+        self.assertEqual(fkm.collect_wxid_candidates("/random/path"), [])
+
+    def test_xwechat_files_at_end_returns_empty(self):
+        self.assertEqual(fkm.collect_wxid_candidates("/x/xwechat_files"), [])
+
+
+class VerifyAesKeyTests(unittest.TestCase):
+    KEY = "b73bd4126969d30f"
+
+    def _encrypt(self, plaintext_16):
+        return AES.new(self.KEY.encode("ascii"), AES.MODE_ECB).encrypt(plaintext_16)
+
+    def test_jpeg_magic_passes(self):
+        ct = self._encrypt(b"\xff\xd8\xff\xe0" + b"\x00" * 12)
+        self.assertTrue(fkm.verify_aes_key(self.KEY, ct))
+
+    def test_png_magic_passes(self):
+        ct = self._encrypt(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        self.assertTrue(fkm.verify_aes_key(self.KEY, ct))
+
+    def test_gif_magic_passes(self):
+        ct = self._encrypt(b"GIF89a" + b"\x00" * 10)
+        self.assertTrue(fkm.verify_aes_key(self.KEY, ct))
+
+    def test_wxgf_magic_passes(self):
+        ct = self._encrypt(b"wxgf" + b"\x00" * 12)
+        self.assertTrue(fkm.verify_aes_key(self.KEY, ct))
+
+    def test_random_data_fails(self):
+        self.assertFalse(fkm.verify_aes_key(self.KEY, bytes(range(16))))
+
+    def test_wrong_length_template_fails(self):
+        self.assertFalse(fkm.verify_aes_key(self.KEY, b"short"))
+        self.assertFalse(fkm.verify_aes_key(self.KEY, b""))
+
+    def test_short_aes_key_fails(self):
+        self.assertFalse(fkm.verify_aes_key("short", b"\x00" * 16))
+
+    def test_empty_aes_key_fails(self):
+        self.assertFalse(fkm.verify_aes_key("", b"\x00" * 16))
+
+
+class VerifyAesKeyAgainstAllTests(unittest.TestCase):
+    """交叉验证：必须所有模板都通过才算命中（防短 magic 偶然碰撞）。"""
+
+    KEY = "b73bd4126969d30f"
+
+    def _encrypt(self, plaintext_16):
+        return AES.new(self.KEY.encode("ascii"), AES.MODE_ECB).encrypt(plaintext_16)
+
+    def test_all_templates_pass(self):
+        ct1 = self._encrypt(b"\xff\xd8\xff\xe0" + b"\x00" * 12)
+        ct2 = self._encrypt(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        self.assertTrue(fkm.verify_aes_key_against_all(self.KEY, [ct1, ct2]))
+
+    def test_one_template_fails_overall_fails(self):
+        ct1 = self._encrypt(b"\xff\xd8\xff\xe0" + b"\x00" * 12)  # passes
+        ct2 = bytes(range(16))                                    # random, fails
+        self.assertFalse(fkm.verify_aes_key_against_all(self.KEY, [ct1, ct2]))
+
+    def test_empty_template_list_returns_false(self):
+        # 没模板就不能验证；不视为通过（防"零样本=自动通过"陷阱）
+        self.assertFalse(fkm.verify_aes_key_against_all(self.KEY, []))
+
+
+class FindV2TemplateCiphertextsTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.dir = self._tmp.name
+
+    def _build_v2_dat(self, name, ciphertext_16, subdir=""):
+        target_dir = os.path.join(self.dir, subdir) if subdir else self.dir
+        os.makedirs(target_dir, exist_ok=True)
+        path = os.path.join(target_dir, name)
+        with open(path, "wb") as f:
+            f.write(fkm.V2_MAGIC + b"\x00" * 9 + ciphertext_16 + b"\x00\x00")
+        return path
+
+    def test_finds_one_template_in_v2_thumb(self):
+        ct = bytes(range(0xF, 0x1F))
+        self._build_v2_dat("abc_t.dat", ct)
+        result = fkm.find_v2_template_ciphertexts(self.dir)
+        self.assertEqual(result, [ct])
+
+    def test_finds_multiple_distinct_templates(self):
+        cts = [bytes([i] * 16) for i in (0x11, 0x22, 0x33)]
+        for i, ct in enumerate(cts):
+            self._build_v2_dat(f"chat{i}_t.dat", ct, subdir=f"chat{i}")
+        result = fkm.find_v2_template_ciphertexts(self.dir, max_templates=3)
+        self.assertEqual(set(result), set(cts))
+
+    def test_dedupes_identical_templates(self):
+        ct = b"\x42" * 16
+        self._build_v2_dat("a_t.dat", ct, subdir="a")
+        self._build_v2_dat("b_t.dat", ct, subdir="b")
+        result = fkm.find_v2_template_ciphertexts(self.dir)
+        self.assertEqual(result, [ct])
+
+    def test_falls_back_to_any_dat_if_no_thumb(self):
+        ct = b"\x33" * 16
+        self._build_v2_dat("only_full.dat", ct)
+        self.assertEqual(fkm.find_v2_template_ciphertexts(self.dir), [ct])
+
+    def test_skips_non_v2_files(self):
+        path = os.path.join(self.dir, "abc_t.dat")
+        with open(path, "wb") as f:
+            f.write(b"\x00" * 100)
+        self.assertEqual(fkm.find_v2_template_ciphertexts(self.dir), [])
+
+    def test_empty_dir_returns_empty(self):
+        self.assertEqual(fkm.find_v2_template_ciphertexts(self.dir), [])
+
+    def test_missing_dir_returns_empty(self):
+        self.assertEqual(fkm.find_v2_template_ciphertexts("/nonexistent"), [])
+
+    def test_walks_into_subdirs(self):
+        ct = b"\x44" * 16
+        self._build_v2_dat("x_t.dat", ct, subdir="sub/deeper")
+        self.assertEqual(fkm.find_v2_template_ciphertexts(self.dir), [ct])
+
+    def test_respects_max_templates(self):
+        cts = [bytes([i] * 16) for i in range(10)]
+        for i, ct in enumerate(cts):
+            self._build_v2_dat(f"x{i}_t.dat", ct, subdir=f"d{i}")
+        result = fkm.find_v2_template_ciphertexts(self.dir, max_templates=2)
+        self.assertEqual(len(result), 2)
+
+
+class FindImageKeyMacosIntegrationTests(unittest.TestCase):
+    """端到端集成：合成 kvcomm 文件 + 合成 V2 模板 → 期望派生出已知 key。"""
+
+    def _build_test_env(self, tmpdir, code, wxid_raw, num_templates=2):
+        """构造测试环境，返回 (db_dir, expected_xor, expected_aes)。"""
+        wxid_norm = fkm.normalize_wxid(wxid_raw)
+        base = os.path.join(tmpdir, "Documents", "xwechat_files", wxid_raw)
+        db_dir = os.path.join(base, "db_storage")
+        os.makedirs(db_dir)
+
+        kvcomm = os.path.join(tmpdir, "Documents", "app_data", "net", "kvcomm")
+        os.makedirs(kvcomm)
+        with open(os.path.join(kvcomm, f"key_{code}_x.statistic"), "w") as f:
+            f.write("")
+
+        xor_expected, aes_expected = fkm.derive_image_keys(code, wxid_norm)
+        # 多个模板用不同的 plaintext 加密（仍是图像 magic 开头但内容不同）
+        plaintexts = [
+            b"\xff\xd8\xff\xe0" + b"\x00" * 12,           # JPEG
+            b"\x89PNG\r\n\x1a\n" + b"\x00" * 8,           # PNG
+            b"GIF89a" + b"\x01\x02" + b"\x00" * 8,        # GIF
+        ]
+        for i in range(num_templates):
+            pt = plaintexts[i % len(plaintexts)]
+            ct = AES.new(aes_expected.encode("ascii"), AES.MODE_ECB).encrypt(pt)
+            attach = os.path.join(base, "msg", "attach", f"chat{i}")
+            os.makedirs(attach)
+            with open(os.path.join(attach, f"img{i}_t.dat"), "wb") as f:
+                f.write(fkm.V2_MAGIC + b"\x00" * 9 + ct + b"\x00\x00")
+        return db_dir, xor_expected, aes_expected
+
+    def test_full_flow_succeeds_with_normalized_wxid(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_dir, xor_exp, aes_exp = self._build_test_env(
+                tmp, code=18709375, wxid_raw="your_wxid_a1b2c3", num_templates=3)
+            result = fkm.find_image_key_macos(db_dir)
+            self.assertIsNotNone(result, "派生应该成功")
+            self.assertEqual(result, (xor_exp, aes_exp))
+
+    def test_returns_none_when_no_kvcomm_codes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "Documents", "xwechat_files", "wxid_x")
+            db_dir = os.path.join(base, "db_storage")
+            os.makedirs(db_dir)
+            self.assertIsNone(fkm.find_image_key_macos(db_dir))
+
+    def test_returns_none_when_no_v2_template(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "Documents", "xwechat_files", "wxid_x")
+            db_dir = os.path.join(base, "db_storage")
+            os.makedirs(db_dir)
+            kvcomm = os.path.join(tmp, "Documents", "app_data", "net", "kvcomm")
+            os.makedirs(kvcomm)
+            with open(os.path.join(kvcomm, "key_42_x.statistic"), "w") as f:
+                f.write("")
+            self.assertIsNone(fkm.find_image_key_macos(db_dir))
+
+    def test_returns_none_when_no_combination_verifies(self):
+        # 有 code 也有 V2 .dat，但密文是随机的，没有任何 key 能解出
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "Documents", "xwechat_files", "wxid_x")
+            db_dir = os.path.join(base, "db_storage")
+            os.makedirs(db_dir)
+            kvcomm = os.path.join(tmp, "Documents", "app_data", "net", "kvcomm")
+            os.makedirs(kvcomm)
+            with open(os.path.join(kvcomm, "key_42_x.statistic"), "w") as f:
+                f.write("")
+            attach = os.path.join(base, "msg", "attach", "x")
+            os.makedirs(attach)
+            with open(os.path.join(attach, "x_t.dat"), "wb") as f:
+                f.write(fkm.V2_MAGIC + b"\x00" * 9 + b"\xde\xad\xbe\xef" * 4 + b"\x00\x00")
+            self.assertIsNone(fkm.find_image_key_macos(db_dir))
+
+    def test_empty_db_dir_returns_none_without_crash(self):
+        # 防御：空字符串、不合理路径不应抛异常。
+        # patch expanduser 让 HOME fallback 也指向不存在的路径，避免
+        # 测试在装了真实微信的开发机上意外深入到 wxid 缺失分支。
+        with tempfile.TemporaryDirectory() as fake_home:
+            with patch("os.path.expanduser", return_value=fake_home):
+                self.assertIsNone(fkm.find_image_key_macos(""))
+
+
+class MainShortCircuitTests(unittest.TestCase):
+    """main() 短路：已有 image_aes_key 仍然有效时，不应重新派生 / 不应改写 config。"""
+
+    def test_existing_valid_key_skips_derivation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wxid = "wxid_abc"
+            base = os.path.join(tmp, "Documents", "xwechat_files", wxid)
+            db_dir = os.path.join(base, "db_storage")
+            os.makedirs(db_dir)
+
+            # kvcomm 里放个 code，证明若真去派生也能算出 key
+            kvcomm = os.path.join(tmp, "Documents", "app_data", "net", "kvcomm")
+            os.makedirs(kvcomm)
+            code = 42
+            with open(os.path.join(kvcomm, f"key_{code}_x.statistic"), "w") as f:
+                f.write("")
+
+            # 用真实派生的 key 加密 V2 模板，使现有 key 在该模板上能验证通过
+            xor_exp, aes_exp = fkm.derive_image_keys(code, wxid)
+            jpeg_pt = b"\xff\xd8\xff\xe0" + b"\x00" * 12
+            ct = AES.new(aes_exp.encode("ascii"), AES.MODE_ECB).encrypt(jpeg_pt)
+            attach = os.path.join(base, "msg", "attach", "x")
+            os.makedirs(attach)
+            with open(os.path.join(attach, "test_t.dat"), "wb") as f:
+                f.write(fkm.V2_MAGIC + b"\x00" * 9 + ct + b"\x00\x00")
+
+            # 写入"已有有效 key"的 config
+            cfg_path = os.path.join(tmp, "config.json")
+            cfg_initial = {
+                "db_dir": db_dir,
+                "image_aes_key": aes_exp,
+                "image_xor_key": xor_exp,
+                "extra_field": "must_be_preserved",  # 证明 main 不会重写
+            }
+            with open(cfg_path, "w", encoding="utf-8") as f:
+                json.dump(cfg_initial, f)
+            mtime_before = os.path.getmtime(cfg_path)
+
+            # 关键：patch find_image_key_macos 让它若被误调用立刻可见
+            with patch.object(fkm, "find_image_key_macos") as mock_derive:
+                fkm.main(config_path=cfg_path)
+
+            mock_derive.assert_not_called()  # 短路应直接 return，不进派生
+            # config.json 不应被重写
+            self.assertEqual(os.path.getmtime(cfg_path), mtime_before)
+            with open(cfg_path, encoding="utf-8") as f:
+                self.assertEqual(json.load(f), cfg_initial)
+
+    def test_existing_invalid_key_falls_through_to_derivation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wxid = "wxid_abc"
+            base = os.path.join(tmp, "Documents", "xwechat_files", wxid)
+            db_dir = os.path.join(base, "db_storage")
+            os.makedirs(db_dir)
+
+            kvcomm = os.path.join(tmp, "Documents", "app_data", "net", "kvcomm")
+            os.makedirs(kvcomm)
+            code = 42
+            with open(os.path.join(kvcomm, f"key_{code}_x.statistic"), "w") as f:
+                f.write("")
+
+            xor_exp, aes_exp = fkm.derive_image_keys(code, wxid)
+            jpeg_pt = b"\xff\xd8\xff\xe0" + b"\x00" * 12
+            ct = AES.new(aes_exp.encode("ascii"), AES.MODE_ECB).encrypt(jpeg_pt)
+            attach = os.path.join(base, "msg", "attach", "x")
+            os.makedirs(attach)
+            with open(os.path.join(attach, "test_t.dat"), "wb") as f:
+                f.write(fkm.V2_MAGIC + b"\x00" * 9 + ct + b"\x00\x00")
+
+            cfg_path = os.path.join(tmp, "config.json")
+            cfg_initial = {
+                "db_dir": db_dir,
+                "image_aes_key": "deadbeefdeadbeef",  # 故意写一个错的
+            }
+            with open(cfg_path, "w", encoding="utf-8") as f:
+                json.dump(cfg_initial, f)
+
+            fkm.main(config_path=cfg_path)
+
+            # 短路应失败，进入派生路径，配置应被改写为正确的 key
+            with open(cfg_path, encoding="utf-8") as f:
+                cfg_after = json.load(f)
+            self.assertEqual(cfg_after["image_aes_key"], aes_exp)
+            self.assertEqual(cfg_after["image_xor_key"], xor_exp)
+
+
+class SaveConfigAtomicTests(unittest.TestCase):
+    """原子写测试：os.replace 保证 config.json 不会被半截覆盖。"""
+
+    def test_roundtrip_writes_pretty_utf8(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_path = os.path.join(tmp, "config.json")
+            cfg = {"db_dir": "/x", "image_aes_key": "中文测试key"}
+            fkm._save_config_atomic(cfg_path, cfg)
+            with open(cfg_path, encoding="utf-8") as f:
+                self.assertEqual(json.load(f), cfg)
+            # ensure_ascii=False：中文应直接落盘，不被转义
+            with open(cfg_path, "rb") as f:
+                self.assertIn("中文测试key".encode("utf-8"), f.read())
+
+    def test_failed_replace_leaves_original_intact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            cfg_path = os.path.join(tmp, "config.json")
+            with open(cfg_path, "w", encoding="utf-8") as f:
+                json.dump({"original": True}, f)
+            with patch.object(os, "replace",
+                              side_effect=OSError("disk full during rename")):
+                with self.assertRaises(OSError):
+                    fkm._save_config_atomic(cfg_path, {"new": True})
+            # 原文件应保持不变
+            with open(cfg_path, encoding="utf-8") as f:
+                self.assertEqual(json.load(f), {"original": True})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_find_image_key_macos.py
+++ b/tests/test_find_image_key_macos.py
@@ -22,8 +22,8 @@ class NormalizeWxidTests(unittest.TestCase):
         self.assertEqual(fkm.normalize_wxid("wxid_abc123"), "wxid_abc123")
 
     def test_account_with_4char_alnum_suffix_stripped(self):
-        # macOS 路径常见：your_wxid_a1b2c3 → your_wxid
-        self.assertEqual(fkm.normalize_wxid("your_wxid_a1b2c3"), "your_wxid")
+        # macOS 路径常见：your_wxid_a1b2 → your_wxid
+        self.assertEqual(fkm.normalize_wxid("your_wxid_a1b2"), "your_wxid")
 
     def test_account_without_recognizable_suffix_returned_asis(self):
         self.assertEqual(fkm.normalize_wxid("simple"), "simple")
@@ -52,7 +52,7 @@ class DeriveImageKeysTests(unittest.TestCase):
 
     def test_aes_does_not_normalize_wxid_internally(self):
         # 归一化由调用方负责；不同 wxid 字符串产出不同 key
-        _, aes_full = fkm.derive_image_keys(18709375, "your_wxid_a1b2c3")
+        _, aes_full = fkm.derive_image_keys(18709375, "your_wxid_a1b2")
         _, aes_norm = fkm.derive_image_keys(18709375, "your_wxid")
         self.assertNotEqual(aes_full, aes_norm)
 
@@ -150,9 +150,9 @@ class CollectKvcommCodesTests(unittest.TestCase):
 
 class CollectWxidCandidatesTests(unittest.TestCase):
     def test_returns_raw_and_normalized_when_different(self):
-        db_dir = "/x/Documents/xwechat_files/your_wxid_a1b2c3/db_storage"
+        db_dir = "/x/Documents/xwechat_files/your_wxid_a1b2/db_storage"
         self.assertEqual(fkm.collect_wxid_candidates(db_dir),
-                         ["your_wxid_a1b2c3", "your_wxid"])
+                         ["your_wxid_a1b2", "your_wxid"])
 
     def test_returns_one_when_normalize_is_identity(self):
         db_dir = "/x/Documents/xwechat_files/wxid_abc/db_storage"
@@ -322,7 +322,7 @@ class FindImageKeyMacosIntegrationTests(unittest.TestCase):
     def test_full_flow_succeeds_with_normalized_wxid(self):
         with tempfile.TemporaryDirectory() as tmp:
             db_dir, xor_exp, aes_exp = self._build_test_env(
-                tmp, code=18709375, wxid_raw="your_wxid_a1b2c3", num_templates=3)
+                tmp, code=18709375, wxid_raw="your_wxid_a1b2", num_templates=3)
             result = fkm.find_image_key_macos(db_dir)
             self.assertIsNotNone(result, "派生应该成功")
             self.assertEqual(result, (xor_exp, aes_exp))
@@ -454,6 +454,206 @@ class MainShortCircuitTests(unittest.TestCase):
                 cfg_after = json.load(f)
             self.assertEqual(cfg_after["image_aes_key"], aes_exp)
             self.assertEqual(cfg_after["image_xor_key"], xor_exp)
+
+
+# ---------- 方案2 (wxid 后缀候选搜索, fallback) 单元测试 ---------- #
+
+class ExtractWxidPartsTests(unittest.TestCase):
+    """extract_wxid_parts: 从 db_dir 提 (full, norm, suffix)。"""
+
+    def test_extracts_norm_and_suffix_from_alnum_suffix(self):
+        db_dir = "/foo/Documents/xwechat_files/your_wxid_626a/db_storage"
+        self.assertEqual(
+            fkm.extract_wxid_parts(db_dir),
+            ("your_wxid_626a", "your_wxid", "626a"),
+        )
+
+    def test_wxid_format_with_4char_suffix(self):
+        db_dir = "/foo/Documents/xwechat_files/wxid_abc_e2f4/db_storage"
+        self.assertEqual(
+            fkm.extract_wxid_parts(db_dir),
+            ("wxid_abc_e2f4", "wxid_abc", "e2f4"),
+        )
+
+    def test_uppercase_suffix_lowercased(self):
+        db_dir = "/foo/Documents/xwechat_files/your_wxid_ABCD/db_storage"
+        result = fkm.extract_wxid_parts(db_dir)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[2], "abcd")
+
+    def test_no_4char_suffix_returns_none(self):
+        # 6字符尾缀不匹配 _<4字符>$, 算法假设破灭
+        db_dir = "/foo/Documents/xwechat_files/wxid_simple/db_storage"
+        self.assertIsNone(fkm.extract_wxid_parts(db_dir))
+
+    def test_no_xwechat_files_returns_none(self):
+        self.assertIsNone(fkm.extract_wxid_parts("/random/path/db_storage"))
+
+
+class DeriveXorKeyFromV2DatTests(unittest.TestCase):
+    """derive_xor_key_from_v2_dat: 末字节投票反推 xor_key。"""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = self.tmp.name
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _write_v2_dat(self, name, last_byte, subdir=""):
+        d = os.path.join(self.dir, subdir) if subdir else self.dir
+        os.makedirs(d, exist_ok=True)
+        body = (fkm.V2_MAGIC + b"\x00" * 9 + b"\x11" * 16
+                + b"\x00" * 4 + bytes([last_byte]))
+        with open(os.path.join(d, name), "wb") as f:
+            f.write(body)
+
+    def test_unanimous_vote(self):
+        # 全部末字节 = 0xA6 → xor_key = 0xA6 ^ 0xD9 = 0x7F
+        for i in range(10):
+            self._write_v2_dat(f"x{i}_t.dat", 0xA6)
+        self.assertEqual(fkm.derive_xor_key_from_v2_dat(self.dir),
+                         (0x7F, 10, 10))
+
+    def test_majority_vote_with_dissent(self):
+        # 8 个 0xA6, 2 个 0x55: 多数 0x7F 胜出
+        for i in range(8):
+            self._write_v2_dat(f"good{i}_t.dat", 0xA6)
+        for i in range(2):
+            self._write_v2_dat(f"bad{i}_t.dat", 0x55)
+        result = fkm.derive_xor_key_from_v2_dat(self.dir)
+        self.assertEqual(result, (0x7F, 8, 10))
+
+    def test_no_v2_dat_returns_none(self):
+        self.assertIsNone(fkm.derive_xor_key_from_v2_dat(self.dir))
+
+    def test_below_min_samples_returns_none(self):
+        # 默认 min_samples=3, 仅有 2 个样本应被视为不可信
+        for i in range(2):
+            self._write_v2_dat(f"x{i}_t.dat", 0xA6)
+        self.assertIsNone(fkm.derive_xor_key_from_v2_dat(self.dir))
+
+    def test_missing_dir_returns_none(self):
+        self.assertIsNone(fkm.derive_xor_key_from_v2_dat("/nonexistent"))
+
+    def test_walks_into_subdirs(self):
+        for i in range(10):
+            self._write_v2_dat(f"x{i}_t.dat", 0xA6, subdir=f"deep/sub{i}")
+        result = fkm.derive_xor_key_from_v2_dat(self.dir)
+        self.assertIsNotNone(result)
+        self.assertEqual(result[0], 0x7F)
+
+    def test_skips_non_v2_files(self):
+        # 不是 V2 magic 的 .dat 不计入投票
+        with open(os.path.join(self.dir, "junk.dat"), "wb") as f:
+            f.write(b"NOT_V2" + b"\x00" * 30)
+        for i in range(10):
+            self._write_v2_dat(f"x{i}_t.dat", 0xA6)
+        result = fkm.derive_xor_key_from_v2_dat(self.dir)
+        self.assertEqual(result, (0x7F, 10, 10))
+
+
+class BruteforceUinCandidatesTests(unittest.TestCase):
+    """bruteforce_uin_candidates: 候选枚举 + md5 前缀匹配。
+
+    注意：test_real_bruteforce_against_golden 单核 ~7-8 秒，全套测试耗时大头。
+    """
+
+    def test_real_bruteforce_against_golden(self):
+        # 真跑全空间 2^24 候选, 同时验证: (a) 真 uin 在结果里
+        # (b) 候选数合理 (~256) (c) 候选都满足 xor_key 约束
+        # md5("18709375")[:4] == "626a", 18709375 & 0xff == 0x7F
+        out = fkm.bruteforce_uin_candidates(0x7F, "626a")
+        self.assertIn(18709375, out, "真 uin 应在候选里")
+        self.assertTrue(200 <= len(out) <= 350,
+                        f"候选数 {len(out)} 偏离 ~256 (理论 2^24/2^16)")
+        for uin in out[:20]:
+            self.assertEqual(uin & 0xFF, 0x7F,
+                             f"uin {uin} 不满足 xor_key 约束")
+
+
+
+class FindViaBruteforceTests(unittest.TestCase):
+    """方案2 端到端 (mock bruteforce 加速)。"""
+
+    def _build_bruteforce_env(self, tmp, uin, wxid_norm, suffix):
+        wxid_full = f"{wxid_norm}_{suffix}"
+        base = os.path.join(tmp, "Documents", "xwechat_files", wxid_full)
+        db_dir = os.path.join(base, "db_storage")
+        attach_dir = os.path.join(base, "msg", "attach")
+        os.makedirs(db_dir)
+        os.makedirs(attach_dir)
+        xor_exp, aes_exp = fkm.derive_image_keys(uin, wxid_norm)
+        last_byte = 0xD9 ^ xor_exp
+        jpeg_pt = b"\xff\xd8\xff\xe0" + b"\x00" * 12
+        ct = AES.new(aes_exp.encode("ascii"), AES.MODE_ECB).encrypt(jpeg_pt)
+        # 构造 10 个 V2 dat 让 derive_xor_key 投票稳定
+        for i in range(10):
+            with open(os.path.join(attach_dir, f"img{i}_t.dat"), "wb") as f:
+                f.write(fkm.V2_MAGIC + b"\x00" * 9 + ct
+                        + b"\x00" * 4 + bytes([last_byte]))
+        return db_dir, attach_dir, xor_exp, aes_exp
+
+    def test_full_flow_with_mocked_bruteforce(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_dir, attach_dir, xor_exp, aes_exp = self._build_bruteforce_env(
+                tmp, uin=18709375, wxid_norm="your_wxid", suffix="626a")
+            templates = fkm.find_v2_template_ciphertexts(attach_dir)
+            with patch.object(fkm, "bruteforce_uin_candidates",
+                              return_value=[18709375]):
+                result = fkm._find_via_bruteforce(db_dir, attach_dir, templates)
+            self.assertEqual(result, (xor_exp, aes_exp))
+
+    def test_returns_none_when_no_wxid_suffix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "Documents", "xwechat_files", "wxid_nosuffix")
+            db_dir = os.path.join(base, "db_storage")
+            attach_dir = os.path.join(base, "msg", "attach")
+            os.makedirs(db_dir)
+            os.makedirs(attach_dir)
+            self.assertIsNone(fkm._find_via_bruteforce(db_dir, attach_dir, []))
+
+    def test_returns_none_when_no_v2_dat(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = os.path.join(tmp, "Documents", "xwechat_files",
+                                "your_wxid_626a")
+            db_dir = os.path.join(base, "db_storage")
+            attach_dir = os.path.join(base, "msg", "attach")
+            os.makedirs(db_dir)
+            os.makedirs(attach_dir)
+            self.assertIsNone(fkm._find_via_bruteforce(db_dir, attach_dir, []))
+
+
+class DispatcherFallbackTests(unittest.TestCase):
+    """find_image_key_macos dispatcher: 方案1 失败 → fallback 方案2。"""
+
+    def test_kvcomm_missing_falls_back_to_bruteforce(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            uin, wxid_norm, suffix = 18709375, "your_wxid", "626a"
+            wxid_full = f"{wxid_norm}_{suffix}"
+            base = os.path.join(tmp, "Documents", "xwechat_files", wxid_full)
+            db_dir = os.path.join(base, "db_storage")
+            attach_dir = os.path.join(base, "msg", "attach")
+            os.makedirs(db_dir)
+            os.makedirs(attach_dir)
+
+            # 不创建 kvcomm → 方案1 失败
+            xor_exp, aes_exp = fkm.derive_image_keys(uin, wxid_norm)
+            last_byte = 0xD9 ^ xor_exp
+            jpeg_pt = b"\xff\xd8\xff\xe0" + b"\x00" * 12
+            ct = AES.new(aes_exp.encode("ascii"), AES.MODE_ECB).encrypt(jpeg_pt)
+            for i in range(10):
+                with open(os.path.join(attach_dir, f"img{i}_t.dat"), "wb") as f:
+                    f.write(fkm.V2_MAGIC + b"\x00" * 9 + ct
+                            + b"\x00" * 4 + bytes([last_byte]))
+
+            # patch HOME 让兜底 kvcomm 路径也找不到
+            # mock bruteforce 加速 (只返回真 uin)
+            with patch("os.path.expanduser", return_value=tmp), \
+                 patch.object(fkm, "bruteforce_uin_candidates",
+                              return_value=[uin]):
+                result = fkm.find_image_key_macos(db_dir)
+            self.assertEqual(result, (xor_exp, aes_exp))
 
 
 class SaveConfigAtomicTests(unittest.TestCase):

--- a/tests/test_find_image_key_macos.py
+++ b/tests/test_find_image_key_macos.py
@@ -45,15 +45,16 @@ class DeriveImageKeysTests(unittest.TestCase):
         self.assertEqual(fkm.derive_image_keys(0x00, "x")[0], 0x00)
 
     def test_aes_is_md5_hex_truncated_to_16(self):
-        # Golden value：来自 POC 在真实微信数据上的验证（issue #23 解的就是这一对）
-        xor, aes = fkm.derive_image_keys(18709375, "your_wxid")
-        self.assertEqual(xor, 0x7F)
-        self.assertEqual(aes, "b73bd4126969d30f")
+        # Golden value: 合成 fixture (uin=12345678) 派生; 算法正确性由公式
+        # md5(str(uin)+wxid)[:16] 决定, 测试值无需对应任何真实账号。
+        xor, aes = fkm.derive_image_keys(12345678, "your_wxid")
+        self.assertEqual(xor, 0x4E)  # 12345678 & 0xFF
+        self.assertEqual(aes, "a0c093edddc98490")
 
     def test_aes_does_not_normalize_wxid_internally(self):
         # 归一化由调用方负责；不同 wxid 字符串产出不同 key
-        _, aes_full = fkm.derive_image_keys(18709375, "your_wxid_a1b2")
-        _, aes_norm = fkm.derive_image_keys(18709375, "your_wxid")
+        _, aes_full = fkm.derive_image_keys(12345678, "your_wxid_a1b2")
+        _, aes_norm = fkm.derive_image_keys(12345678, "your_wxid")
         self.assertNotEqual(aes_full, aes_norm)
 
 
@@ -125,12 +126,14 @@ class CollectKvcommCodesTests(unittest.TestCase):
             f.write("")
 
     def test_extracts_code_from_filename(self):
-        self._touch("key_18709375_4066645761_1_1777096531_137785059_3600_input.statistic")
+        # 长格式: 模拟真实 kvcomm 缓存文件命名 (合成 ID/时间戳, 测 regex 提
+        # uin 的能力, 不绑定任何真实账号)
+        self._touch("key_12345678_1111111111_1_1700000000_22222_3600_input.statistic")
         self._touch("key_99999999_yyy_zzz.statistic")
-        self.assertEqual(fkm.collect_kvcomm_codes(self.kvdir), [18709375, 99999999])
+        self.assertEqual(fkm.collect_kvcomm_codes(self.kvdir), [12345678, 99999999])
 
     def test_ignores_files_with_non_numeric_first_segment(self):
-        self._touch("key_reportnow_18709375_xxx.statistic")
+        self._touch("key_reportnow_12345678_xxx.statistic")
         self._touch("key_abc_def.statistic")
         self._touch("config.ini")
         self._touch("monitordata_x")
@@ -166,7 +169,7 @@ class CollectWxidCandidatesTests(unittest.TestCase):
 
 
 class VerifyAesKeyTests(unittest.TestCase):
-    KEY = "b73bd4126969d30f"
+    KEY = "a0c093edddc98490"
 
     def _encrypt(self, plaintext_16):
         return AES.new(self.KEY.encode("ascii"), AES.MODE_ECB).encrypt(plaintext_16)
@@ -204,7 +207,7 @@ class VerifyAesKeyTests(unittest.TestCase):
 class VerifyAesKeyAgainstAllTests(unittest.TestCase):
     """交叉验证：必须所有模板都通过才算命中（防短 magic 偶然碰撞）。"""
 
-    KEY = "b73bd4126969d30f"
+    KEY = "a0c093edddc98490"
 
     def _encrypt(self, plaintext_16):
         return AES.new(self.KEY.encode("ascii"), AES.MODE_ECB).encrypt(plaintext_16)
@@ -322,7 +325,7 @@ class FindImageKeyMacosIntegrationTests(unittest.TestCase):
     def test_full_flow_succeeds_with_normalized_wxid(self):
         with tempfile.TemporaryDirectory() as tmp:
             db_dir, xor_exp, aes_exp = self._build_test_env(
-                tmp, code=18709375, wxid_raw="your_wxid_a1b2", num_templates=3)
+                tmp, code=12345678, wxid_raw="your_wxid_a1b2", num_templates=3)
             result = fkm.find_image_key_macos(db_dir)
             self.assertIsNotNone(result, "派生应该成功")
             self.assertEqual(result, (xor_exp, aes_exp))
@@ -462,10 +465,10 @@ class ExtractWxidPartsTests(unittest.TestCase):
     """extract_wxid_parts: 从 db_dir 提 (full, norm, suffix)。"""
 
     def test_extracts_norm_and_suffix_from_alnum_suffix(self):
-        db_dir = "/foo/Documents/xwechat_files/your_wxid_626a/db_storage"
+        db_dir = "/foo/Documents/xwechat_files/your_wxid_25d5/db_storage"
         self.assertEqual(
             fkm.extract_wxid_parts(db_dir),
-            ("your_wxid_626a", "your_wxid", "626a"),
+            ("your_wxid_25d5", "your_wxid", "25d5"),
         )
 
     def test_wxid_format_with_4char_suffix(self):
@@ -560,15 +563,15 @@ class BruteforceUinCandidatesTests(unittest.TestCase):
     """
 
     def test_real_bruteforce_against_golden(self):
-        # 真跑全空间 2^24 候选, 同时验证: (a) 真 uin 在结果里
+        # 真跑全空间 2^24 候选, 同时验证: (a) 合成 uin 在结果里
         # (b) 候选数合理 (~256) (c) 候选都满足 xor_key 约束
-        # md5("18709375")[:4] == "626a", 18709375 & 0xff == 0x7F
-        out = fkm.bruteforce_uin_candidates(0x7F, "626a")
-        self.assertIn(18709375, out, "真 uin 应在候选里")
+        # md5("12345678")[:4] == "25d5", 12345678 & 0xff == 0x4E
+        out = fkm.bruteforce_uin_candidates(0x4E, "25d5")
+        self.assertIn(12345678, out, "合成 uin 应在候选里")
         self.assertTrue(200 <= len(out) <= 350,
                         f"候选数 {len(out)} 偏离 ~256 (理论 2^24/2^16)")
         for uin in out[:20]:
-            self.assertEqual(uin & 0xFF, 0x7F,
+            self.assertEqual(uin & 0xFF, 0x4E,
                              f"uin {uin} 不满足 xor_key 约束")
 
 
@@ -597,10 +600,10 @@ class FindViaBruteforceTests(unittest.TestCase):
     def test_full_flow_with_mocked_bruteforce(self):
         with tempfile.TemporaryDirectory() as tmp:
             db_dir, attach_dir, xor_exp, aes_exp = self._build_bruteforce_env(
-                tmp, uin=18709375, wxid_norm="your_wxid", suffix="626a")
+                tmp, uin=12345678, wxid_norm="your_wxid", suffix="25d5")
             templates = fkm.find_v2_template_ciphertexts(attach_dir)
             with patch.object(fkm, "bruteforce_uin_candidates",
-                              return_value=[18709375]):
+                              return_value=[12345678]):
                 result = fkm._find_via_bruteforce(db_dir, attach_dir, templates)
             self.assertEqual(result, (xor_exp, aes_exp))
 
@@ -616,7 +619,7 @@ class FindViaBruteforceTests(unittest.TestCase):
     def test_returns_none_when_no_v2_dat(self):
         with tempfile.TemporaryDirectory() as tmp:
             base = os.path.join(tmp, "Documents", "xwechat_files",
-                                "your_wxid_626a")
+                                "your_wxid_25d5")
             db_dir = os.path.join(base, "db_storage")
             attach_dir = os.path.join(base, "msg", "attach")
             os.makedirs(db_dir)
@@ -629,7 +632,7 @@ class DispatcherFallbackTests(unittest.TestCase):
 
     def test_kvcomm_missing_falls_back_to_bruteforce(self):
         with tempfile.TemporaryDirectory() as tmp:
-            uin, wxid_norm, suffix = 18709375, "your_wxid", "626a"
+            uin, wxid_norm, suffix = 12345678, "your_wxid", "25d5"
             wxid_full = f"{wxid_norm}_{suffix}"
             base = os.path.join(tmp, "Documents", "xwechat_files", wxid_full)
             db_dir = os.path.join(base, "db_storage")

--- a/tests/test_find_image_key_macos.py
+++ b/tests/test_find_image_key_macos.py
@@ -2,8 +2,11 @@
 
 不依赖真实微信数据；用 tempdir + 合成密文构造测试。
 """
+import hashlib
 import json
+import multiprocessing
 import os
+import queue as _queue_mod
 import tempfile
 import unittest
 from unittest.mock import patch
@@ -577,7 +580,11 @@ class BruteforceUinCandidatesTests(unittest.TestCase):
 
 
 class FindViaBruteforceTests(unittest.TestCase):
-    """方案2 端到端 (mock bruteforce 加速)。"""
+    """方案2 端到端 (合成 fixture, 多进程 worker 实跑)。
+
+    注: parallel 路径在合成 uin (低数值, 在 worker 0 chunk 早期命中) 上
+    < 0.2s 完成, 不需要 mock 加速。worker spawn 开销是真实集成测试的合理代价。
+    """
 
     def _build_bruteforce_env(self, tmp, uin, wxid_norm, suffix):
         wxid_full = f"{wxid_norm}_{suffix}"
@@ -597,14 +604,12 @@ class FindViaBruteforceTests(unittest.TestCase):
                         + b"\x00" * 4 + bytes([last_byte]))
         return db_dir, attach_dir, xor_exp, aes_exp
 
-    def test_full_flow_with_mocked_bruteforce(self):
+    def test_full_flow_finds_synthetic_uin(self):
         with tempfile.TemporaryDirectory() as tmp:
             db_dir, attach_dir, xor_exp, aes_exp = self._build_bruteforce_env(
                 tmp, uin=12345678, wxid_norm="your_wxid", suffix="25d5")
             templates = fkm.find_v2_template_ciphertexts(attach_dir)
-            with patch.object(fkm, "bruteforce_uin_candidates",
-                              return_value=[12345678]):
-                result = fkm._find_via_bruteforce(db_dir, attach_dir, templates)
+            result = fkm._find_via_bruteforce(db_dir, attach_dir, templates)
             self.assertEqual(result, (xor_exp, aes_exp))
 
     def test_returns_none_when_no_wxid_suffix(self):
@@ -650,13 +655,87 @@ class DispatcherFallbackTests(unittest.TestCase):
                     f.write(fkm.V2_MAGIC + b"\x00" * 9 + ct
                             + b"\x00" * 4 + bytes([last_byte]))
 
-            # patch HOME 让兜底 kvcomm 路径也找不到
-            # mock bruteforce 加速 (只返回真 uin)
-            with patch("os.path.expanduser", return_value=tmp), \
-                 patch.object(fkm, "bruteforce_uin_candidates",
-                              return_value=[uin]):
+            # patch HOME 让兜底 kvcomm 路径也找不到, 强制走方案2
+            with patch("os.path.expanduser", return_value=tmp):
                 result = fkm.find_image_key_macos(db_dir)
             self.assertEqual(result, (xor_exp, aes_exp))
+
+
+class BruteforceParallelTests(unittest.TestCase):
+    """方案2 多进程实现的两层覆盖:
+    - 算法核心 (_bruteforce_worker_chunk): 直接调用, 无 process spawn, 极快
+    - 集成 (_bruteforce_with_aes_parallel): workers=1 验证 spawn + pickle 链路
+
+    多进程 e2e 由 FindViaBruteforceTests / DispatcherFallbackTests 间接覆盖
+    (cpu_count workers, 真实 fixture)。这里只测函数契约, 避免 spawn 开销
+    被反复支付。
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        # 合成 fixture, 跨多个测试复用
+        cls.uin = 12345678
+        cls.xor_key = cls.uin & 0xFF  # 0x4E
+        cls.wxid_norm = "your_wxid"
+        cls.suffix_hex = hashlib.md5(str(cls.uin).encode()).hexdigest()[:4]
+        cls.suffix_bytes = bytes.fromhex(cls.suffix_hex)
+        cls.aes_hex = hashlib.md5(
+            f"{cls.uin}{cls.wxid_norm}".encode()
+        ).hexdigest()[:16]
+        cls.template = AES.new(
+            cls.aes_hex.encode("ascii"), AES.MODE_ECB
+        ).encrypt(b"\xff\xd8\xff\xe0" + b"\x00" * 12)
+        # i = (uin - xor_key) >> 8: worker 用 i 索引, 主进程倒推区间
+        cls.target_i = (cls.uin - cls.xor_key) >> 8
+
+    # 注: multiprocessing.Queue.put() 通过 feeder thread 异步刷到 pipe,
+    # get_nowait() 读取会 race。所有 queue 读用 get(timeout=...):
+    # - 命中场景: timeout=2s 给 feeder 充足时间 (实际 ~ms 级)
+    # - 不命中场景: timeout=0.5s 既证空又不拖慢测试
+
+    def test_worker_finds_known_uin_in_chunk(self):
+        q = multiprocessing.Queue()
+        fkm._bruteforce_worker_chunk(
+            self.target_i - 50, self.target_i + 50,
+            self.xor_key, self.suffix_bytes,
+            self.wxid_norm.encode("ascii"),
+            [self.template], q,
+        )
+        result = q.get(timeout=2)
+        self.assertEqual(result, (self.uin, self.aes_hex))
+
+    def test_worker_no_match_returns_silently(self):
+        # 区间不含 target_i (~48k), worker 扫完, queue 应保持空
+        q = multiprocessing.Queue()
+        fkm._bruteforce_worker_chunk(
+            0, 1000,
+            self.xor_key, self.suffix_bytes,
+            self.wxid_norm.encode("ascii"),
+            [self.template], q,
+        )
+        with self.assertRaises(_queue_mod.Empty):
+            q.get(timeout=0.5)
+
+    def test_worker_skips_when_aes_fails(self):
+        # md5 prefix 命中但 AES 模板错: 不入队 (防止 md5 单 gate 假阳)
+        q = multiprocessing.Queue()
+        wrong_template = b"\x00" * 16  # AES 解出来非图像 magic
+        fkm._bruteforce_worker_chunk(
+            self.target_i - 50, self.target_i + 50,
+            self.xor_key, self.suffix_bytes,
+            self.wxid_norm.encode("ascii"),
+            [wrong_template], q,
+        )
+        with self.assertRaises(_queue_mod.Empty):
+            q.get(timeout=0.5)
+
+    def test_parallel_workers_1_finds_synthetic_uin(self):
+        # 集成: workers=1 验证 process spawn + pickle + queue 跨进程通信
+        result = fkm._bruteforce_with_aes_parallel(
+            self.xor_key, self.suffix_hex, self.wxid_norm,
+            [self.template], workers=1, timeout=30,
+        )
+        self.assertEqual(result, (self.uin, self.aes_hex))
 
 
 class SaveConfigAtomicTests(unittest.TestCase):


### PR DESCRIPTION
## 解决的问题

[Issue #23](https://github.com/ylytdeng/wechat-decrypt/issues/23) — macOS 用户长期无法用 C 版 `find_image_key_macos` 从微信进程内存读取出有效的 V2 图片访问凭据（197K 候选全部失败）。该 issue 自 2026-03 至今 OPEN，至少 2 位 macOS 用户（M4 Pro + Intel）报告同样问题。

## 改动

新增 `find_image_key_macos.py` —— 完全不同的提取路径。**双方案 dispatcher**：

- **方案1** (主路径)：从磁盘 kvcomm 缓存文件名派生 — ~毫秒级, 来自 [@hicccc77 在 issue #23 的评论](https://github.com/ylytdeng/wechat-decrypt/issues/23)
- **方案2** (fallback)：从 wxid 后缀 + 任意 V2 .dat 候选搜索 — ~7 秒, 来自 [@H3CoF6 在 issue #68 的评论](https://github.com/ylytdeng/wechat-decrypt/issues/68)

两条路径互补：方案1 失败 (kvcomm 缺失 / 多账号歧义 / 首次启动) → 自动 fallback 方案2。

无需扫描内存、无需 root、无需重签名。

## 算法

### 方案1 (kvcomm 缓存派生, 主路径)

```
1. 扫 ~/.../app_data/net/kvcomm/key_<uin>_*.statistic 文件名提取 uin
2. 从 db_dir 提取 wxid 候选（含原值与归一化值，e.g. <wxid>_<4hex> → <wxid>）
3. 对每个 (uin, wxid) 组合派生：
     xor_key = uin & 0xFF
     aes_key = MD5(str(uin) + cleaned_wxid).hex()[:16]   # ASCII 字符串
4. 用 V2 _t.dat 文件 [0xF:0x1F] 16 字节做 AES-128-ECB 模板验证
5. 命中后写回 config.json 的 image_aes_key / image_xor_key
```

### 方案2 (wxid 后缀候选搜索, fallback)

关键洞察：**wxid 目录后 4 位 hex == md5(str(uin))[:4]**。

```
1. 从 db_dir 提 wxid 后 4 位 hex 作为 md5 前缀目标
2. 扫多个 V2 .dat 末字节投票反推 xor_key (假设 JPG EOI 0xD9, 默认至少 3 个样本)
3. 枚举 0~2^32 中 (uin & 0xff == xor_key) 的 2^24 个候选,
   md5(str(uin))[:4] 匹配 wxid 后缀 → 得 ~256 个 uin 候选
4. 对每个候选算 aes_key, 用方案1 已有的 verify_aes_key_against_all
   做 AES 模板交叉验证, 唯一定位 uin
```

## 致谢与归属

- **方案1** (kvcomm 派生) 算法源自 @hicccc77 在 [issue #23 的评论](https://github.com/ylytdeng/wechat-decrypt/issues/23)；参考实现位于其 [WeFlow 项目](https://github.com/hicccc77/WeFlow/blob/dev/electron/services/keyServiceMac.ts) (CC BY-NC-SA 4.0)。
- **方案2** (wxid 后缀候选搜索) 思路源自 @H3CoF6 在 [issue #68 的评论](https://github.com/ylytdeng/wechat-decrypt/issues/68), 提供了 "wxid 后 4 位 == md5(uin)[:4]" 这一关键结构性洞察。

**本 PR 是独立的 Python clean-room 实现**, 未复制 WeFlow TypeScript 源码 / @H3CoF6 任何代码; 函数边界与变量命名沿用算法的自然结构 (regex / MD5 调用顺序 / magic 字节表等不可避免地相同). 模块顶部 docstring 都做了明确署名.

## 健壮性设计

| 维度 | 实现 |
|---|---|
| 多 kvcomm 路径 | 枚举 5 个 macOS 微信版本路径布局, 第一个存在的就用 |
| 多模板交叉验证 | 默认收集 3 个不同 V2 密文, AES 解密结果**全部**符合图像 magic 才算命中 (防短 magic 偶然碰撞) |
| 短路 | 已有 `image_aes_key` 仍能验证通过时, 直接返回不重写 config |
| 原子写 | `config.json` 走 tmp + os.replace + finally 清理 .tmp |
| 多 wxid 候选 | raw 与归一化值同时尝试 |
| 错误诊断 | 各失败分支都给出清晰诊断 |
| **方案2: 投票最小样本数** | 至少 3 个 V2 .dat 才反推 xor_key (避免 1-2 样本撞非 JPG lock 错值) |
| **方案2: 严格 hex 后缀** | regex `[0-9a-fA-F]{4}` 而非宽松 alnum |
| **方案2: 投票分歧 warning** | 多数投票胜出但显示 warning |

## 在本地数据上的验证

在本地 macOS 微信 4.x 上端到端跑通：

- 方案1 (kvcomm) 派生出 (xor_key, aes_key), 用 8 张跨 8 个聊天的 V2 .dat 文件全部成功解出 JPEG / wxgf
- 方案2 (候选搜索) 独立验证, 派生结果与方案1 字节级一致
- xor_key 交叉验证：扫 200 个 V2 _t.dat, 末尾 2 字节模式与派生值完美吻合

## 测试

新增 `tests/test_find_image_key_macos.py`, **74 个测试** 全部 ~8.5s 内通过：

- ExtractWxidPartsTests (5): 各种 wxid 格式
- DeriveXorKeyFromV2DatTests (7): 投票一致 / 分歧 / 子目录递归 / min_samples 边界
- BruteforceUinCandidatesTests (1): 单进程真跑全空间金标准验证
- BruteforceParallelTests (4): worker 直调 + workers=1 spawn 链路验证
- FindViaBruteforceTests (3): 端到端 (合成 fixture, 多进程实跑)
- DispatcherFallbackTests (1): 方案1 失败 → fallback 触发
- 派生算法 / wxid 归一化 / kvcomm 路径 / 模板收集 / AES 验证 / 端到端集成 / 原子写 / main 短路 (53)

测试 fixture 用合成确定性 uin (`12345678`), 不绑定任何真实账号 (行业最佳实践).

## 兼容性

- **零新增依赖** (pycryptodome 已在 requirements.txt)
- **不改任何现有 Python 文件** —— Windows/Linux 路径完全不受影响
- 输出契约 (`config.json` 的 `image_aes_key` / `image_xor_key` 字段) 与 `find_image_key.py:392-394` 完全一致, 下游 `monitor_web.py` 自动加载, 无需任何下游改动

## 范围说明

本 PR 只解决 "提取 V2 图片 key" 这个问题. `mcp_server.py` 的 `decode_image` MCP 工具目前只调用 `xor_decrypt_file` (`decode_image.py:386`), 不读 `image_aes_key` —— 这是另一个独立 bug, **不在本 PR 范围内**, 建议后续单开 PR 处理.

## 用户操作

```bash
python find_image_key_macos.py
```

无需提前在微信中查看图片 (kvcomm 缓存通常已存在); 若 kvcomm 文件还没生成, dispatcher 会自动 fallback 到方案2 (从 wxid 后缀候选搜索).

## 审核流程

提交前经过 3 轮独立 code review (Round 1: 4 MAJOR → Round 3: 零问题). 方案2 集成时跑了多代理对抗 review (工程 + 法务 / 叙事), 共修复 5 BLOCKING + 多个 MAJOR/MINOR.
