### PR TITLE
fix: config.json 路径字段支持 ~ / 环境变量展开

### DIFF
--- a/config.py
+++ b/config.py
@@ -198,11 +198,19 @@ def load_config():
     else:
         cfg = {**_DEFAULT, **cfg}
 
-    # 将相对路径转为绝对路径
+    # 路径展开:先 expanduser(~ 展开)+ expandvars($HOME / %USERPROFILE% 展开),
+    # 再判 isabs;还相对就 join 项目根。这样 config 里既能写
+    # "all_keys.json"(项目根相对),也能写 "~/Documents/wechat_decrypted" /
+    # "$HOME/wechat" / "%USERPROFILE%\\wechat"(跨用户便携)。
+    # 空字串 / null 不再触发 TypeError(用 cfg.get 而非 in)。
     base = os.path.dirname(os.path.abspath(__file__))
+    if cfg.get("db_dir"):
+        cfg["db_dir"] = os.path.expanduser(os.path.expandvars(cfg["db_dir"]))
     for key in ("keys_file", "decrypted_dir", "decoded_image_dir"):
-        if key in cfg and not os.path.isabs(cfg[key]):
-            cfg[key] = os.path.join(base, cfg[key])
+        if cfg.get(key):
+            cfg[key] = os.path.expanduser(os.path.expandvars(cfg[key]))
+            if not os.path.isabs(cfg[key]):
+                cfg[key] = os.path.join(base, cfg[key])
 
     # 自动推导微信数据根目录（db_dir 的上级目录）
     # db_dir 格式: D:\xwechat_files\<wxid>\db_storage


### PR DESCRIPTION
## 问题

`load_config()` 目前对路径只做"绝对或项目根相对"的二分。如果用户在 `config.json` 里写 `~/Documents/wechat_decrypted` 或 `$HOME/wechat`,会被当成项目相对,join 后变成 `<repo>/~/Documents/wechat_decrypted`(字面 `~` 目录),静默错路径,无报错。

复现:
```json
{ "decrypted_dir": "~/Documents/wechat_decrypted" }
```
当前行为:解密文件落到 `<repo>/~/Documents/wechat_decrypted/`。

## 修改

`config.py` 中 `load_config()` 末段:对 `db_dir` / `keys_file` / `decrypted_dir` / `decoded_image_dir` 四个字段先 `expanduser` + `expandvars`,再判 `isabs`。+9 / -3 行,纯 stdlib。

顺手把 `if key in cfg` 改成 `if cfg.get(key)`,避免 `null` / `""` 触发 `TypeError`(原本就是边界 bug,这次顺手收掉)。

## 兼容性

- 已有绝对路径(`D:\\xwechat_files\\...` / `/Users/x/...`):不变
- 已有项目相对(`"all_keys.json"`):不变
- 新增支持:`~/...` / `\$HOME/...` / `%USERPROFILE%\\...`
- 跨 Windows / Linux / macOS 一致(`expanduser` / `expandvars` 在三平台对无 `~` / 无 `\$` / 无 `%` 的路径都是 no-op)

## Test plan
- [x] tilde 展开:`~/foo` → \$HOME/foo
- [x] 环境变量展开:`\$HOME/foo` → /home/user/foo
- [x] 已有绝对路径:`/abs/path` → 不变
- [x] 项目相对:`all_keys.json` → join 项目根
- [x] null / 空字串:不再 TypeError
- [x] 跨平台 spec 验证:literal `%` (如 `100%complete/foo`)不被 `expandvars` 错误处理

🤖 Generated with [Claude Code](https://claude.com/claude-code)