### PR TITLE
feat: 解析合并转发的聊天记录消息（appmsg type=19）+ 文件本地路径查找工具

### DIFF
--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1840,20 +1840,28 @@ def decode_file_message(chat_name: str, local_id: int) -> str:
     if not username:
         return f"找不到聊天对象: {chat_name}"
 
-    db_path, table_name = _find_msg_table_for_user(username)
-    if not db_path or not table_name:
+    # 同一 chat 的消息可能分散在多个 message_N.db 分片中，遍历所有分片查 local_id
+    shards = _find_msg_tables_for_user(username)
+    if not shards:
         return f"找不到 {chat_name} 的消息表"
-    if not _is_safe_msg_table_name(table_name):
-        return f"非法消息表名: {table_name}"
 
-    with closing(sqlite3.connect(db_path)) as conn:
-        row = conn.execute(
-            f"SELECT local_type, create_time, message_content, WCDB_CT_message_content "
-            f"FROM [{table_name}] WHERE local_id=?",
-            (local_id,)
-        ).fetchone()
+    row = None
+    table_name = None
+    for shard in shards:
+        if not _is_safe_msg_table_name(shard['table_name']):
+            continue
+        with closing(sqlite3.connect(shard['db_path'])) as conn:
+            candidate_row = conn.execute(
+                f"SELECT local_type, create_time, message_content, WCDB_CT_message_content "
+                f"FROM [{shard['table_name']}] WHERE local_id=?",
+                (local_id,)
+            ).fetchone()
+        if candidate_row:
+            row = candidate_row
+            table_name = shard['table_name']
+            break
     if not row:
-        return f"找不到 local_id={local_id} 的消息"
+        return f"找不到 local_id={local_id} 的消息（已扫描 {len(shards)} 个分片）"
 
     local_type, create_time, content, ct_compress = row
     base_type, _ = _split_msg_type(local_type)
@@ -1912,6 +1920,14 @@ def decode_file_message(chat_name: str, local_id: int) -> str:
                 f"{escaped_stem}*{glob_mod.escape(ext)}" if ext else f"{escaped_stem}*",
             ):
                 for hit in glob_mod.glob(os.path.join(month_dir, pattern)):
+                    # 有 totallen 时立刻 size 验证：避免月扫命中"同名但 size 不对"的副本
+                    # 阻塞 walk 兜底，最终返回错误文件
+                    if totallen:
+                        try:
+                            if os.path.getsize(hit) != totallen:
+                                continue
+                        except OSError:
+                            continue
                     if hit not in candidates:
                         candidates.append(hit)
 
@@ -1992,20 +2008,28 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
     if not username:
         return f"找不到聊天对象: {chat_name}"
 
-    db_path, table_name = _find_msg_table_for_user(username)
-    if not db_path or not table_name:
+    # 同一 chat 的消息可能分散在多个 message_N.db 分片中，遍历所有分片查 local_id
+    shards = _find_msg_tables_for_user(username)
+    if not shards:
         return f"找不到 {chat_name} 的消息表"
-    if not _is_safe_msg_table_name(table_name):
-        return f"非法消息表名: {table_name}"
 
-    with closing(sqlite3.connect(db_path)) as conn:
-        row = conn.execute(
-            f"SELECT local_type, message_content, WCDB_CT_message_content "
-            f"FROM [{table_name}] WHERE local_id=?",
-            (local_id,)
-        ).fetchone()
+    row = None
+    table_name = None
+    for shard in shards:
+        if not _is_safe_msg_table_name(shard['table_name']):
+            continue
+        with closing(sqlite3.connect(shard['db_path'])) as conn:
+            candidate_row = conn.execute(
+                f"SELECT local_type, message_content, WCDB_CT_message_content "
+                f"FROM [{shard['table_name']}] WHERE local_id=?",
+                (local_id,)
+            ).fetchone()
+        if candidate_row:
+            row = candidate_row
+            table_name = shard['table_name']
+            break
     if not row:
-        return f"找不到 local_id={local_id} 的消息"
+        return f"找不到 local_id={local_id} 的消息（已扫描 {len(shards)} 个分片）"
 
     local_type, content, ct_compress = row
     base_type, _ = _split_msg_type(local_type)
@@ -2091,6 +2115,14 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
         if datatitle:
             escaped_title = glob_mod.escape(datatitle)
             for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, escaped_title)):
+                # 有 datasize 时立刻 size 验证：避免命中"同名但 size 不对"的副本
+                # 阻塞兜底匹配，最终返回错误文件
+                if datasize:
+                    try:
+                        if os.path.getsize(hit) != datasize:
+                            continue
+                    except OSError:
+                        continue
                 if hit not in candidates:
                     candidates.append(hit)
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -449,7 +449,12 @@ def _decompress_content(content, ct):
 
 
 def _parse_message_content(content, local_type, is_group):
-    """解析消息内容，返回 (sender_id, text)"""
+    """解析消息内容，返回 (sender_id, text)。
+
+    群消息 content 形如 'wxid_xxx:\n<xml...>'；但 Codex round-7 实测发现
+    部分 type=19 合并转发也会写成 'wxid_xxx:<?xml...' 或 'wxid_xxx:<msg...'
+    不带换行 → 必须扩展剥离逻辑。
+    """
     if content is None:
         return '', ''
     if isinstance(content, bytes):
@@ -457,8 +462,15 @@ def _parse_message_content(content, local_type, is_group):
 
     sender = ''
     text = content
-    if is_group and ':\n' in content:
-        sender, text = content.split(':\n', 1)
+    if is_group:
+        if ':\n' in content:
+            sender, text = content.split(':\n', 1)
+        else:
+            # 'sender:<?xml...' / 'sender:<msg...' 等无换行 case
+            m = re.match(r'^([A-Za-z0-9_\-@.]+):(<\?xml|<msg|<msglist|<voipmsg|<sysmsg)', content)
+            if m:
+                sender = m.group(1)
+                text = content[len(sender) + 1:]
 
     return sender, text
 
@@ -2109,60 +2121,72 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                 f"  说明：找到了同名文件但 size 都不匹配——可能从未真正下载完整 / 已被清理"
             )
 
-    # 没有 md5 = 没法 cryptographic 证明候选属于该消息 → fail closed。
-    # 之前的 "heuristic + warning" 不够：candidates==1 时 warning 形同虚设，
-    # downstream 会把无关同名同 size 文件当成目标读。Codex round-6 high #1。
+    # 威胁模型：本工具是用户主动通过 MCP 调用，path 只在本地对话显示，调用者
+    # 都是熟人。Codex round-6 强制"没 md5 fail-closed"对此场景过严——
+    # 回退到"有 md5 强校验，没 md5 heuristic + warning"的实用路线（round-5）。
     cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
-    if not (expected_md5 and len(expected_md5) == 32):
+    md5_verified = False
+    if expected_md5 and len(expected_md5) == 32:
+        # 用 md5 过滤候选——同 md5 = 真同一文件副本。
+        md5_match = []
+        md5_errors = []
+        for c in candidates:
+            if not _path_under_root(c, cache_root):
+                md5_errors.append(f"{c}: 不在 {cache_root} 下，跳过")
+                continue
+            actual_md5, err = _md5_file_chunked(c)
+            if err:
+                md5_errors.append(f"{c}: {err}")
+                continue
+            if actual_md5 == expected_md5:
+                md5_match.append(c)
+        if not md5_match:
+            info = (
+                f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
+                f"  期望 md5: {expected_md5}\n"
+                f"  说明：找到 {len(candidates)} 个同名同 size 的本地文件但 md5 都不对。"
+                f"目标文件可能未在 wechat 客户端打开过，或已被清理。"
+            )
+            if md5_errors:
+                info += "\n  校验异常：\n    " + "\n    ".join(md5_errors)
+            return info
+        candidates = md5_match
+        md5_verified = True
+
+    # 没 md5 时多 candidates 仍 fail-closed（避免 silent mtime pick）
+    if len(candidates) > 1 and not md5_verified:
         from datetime import datetime as _dt
         details = []
-        for c in candidates[:5]:
+        for c in candidates:
             try:
                 mt = _dt.fromtimestamp(os.path.getmtime(c)).isoformat()
             except OSError:
                 mt = '?'
             details.append(f"{c} (mtime={mt})")
-        more = "" if len(candidates) <= 5 else f"\n  …还有 {len(candidates) - 5} 个候选"
         return (
-            f"消息 XML 没含 md5 字段，本工具拒绝基于 (filename+size) 启发式返回路径"
-            f"（避免 silent 命中无关消息的同名缓存）:\n  "
+            f"在本地缓存找到 {len(candidates)} 个匹配的副本，无法唯一定位"
+            f"（同名同 size 多份，且消息 XML 没含 md5 用于强校验）:\n  "
             + '\n  '.join(details)
-            + more
-            + f"\n如确实需要这个文件，请人工 inspect 候选并直接 Read 你认可的 path"
+            + f"\n请人工 inspect mtime / 上下文区分"
         )
 
-    # 用 expected_md5 过滤 candidates；同 md5 = 真同一文件副本。
-    md5_match = []
-    md5_errors = []
-    for c in candidates:
-        if not _path_under_root(c, cache_root):
-            md5_errors.append(f"{c}: 不在 {cache_root} 下，跳过")
-            continue
-        actual_md5, err = _md5_file_chunked(c)
-        if err:
-            md5_errors.append(f"{c}: {err}")
-            continue
-        if actual_md5 == expected_md5:
-            md5_match.append(c)
-    if not md5_match:
-        info = (
-            f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
-            f"  期望 md5: {expected_md5}\n"
-            f"  说明：找到 {len(candidates)} 个同名同 size 的本地文件但 md5 都不对。"
-            f"目标文件可能未在 wechat 客户端打开过，或已被清理。"
-        )
-        if md5_errors:
-            info += "\n  校验异常：\n    " + "\n    ".join(md5_errors)
-        return info
+    chosen = candidates[0]
+    if not _path_under_root(chosen, cache_root):
+        return f"匹配到的路径 {chosen!r} 不在 {cache_root} 下，拒绝返回（可能是 symlink 攻击）"
 
-    chosen = md5_match[0]
+    binding_note = (
+        "✅ md5 校验通过，路径与消息唯一绑定"
+        if md5_verified else
+        f"⚠️  消息 XML 没含 md5，路径基于 (filename+size) 启发式匹配——"
+        f"如果同 chat 缓存里另有同名同 size 的不相关文件，可能返回错副本，请人工验证。"
+    )
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
         f"  大小: {os.path.getsize(chosen):,} bytes\n"
         f"  扩展名: {fileext or os.path.splitext(title)[1].lstrip('.') or '?'}\n"
         f"  期望大小: {totallen:,} bytes\n"
-        f"  ✅ md5 校验通过，路径与消息唯一绑定"
+        f"  {binding_note}"
     )
 
 
@@ -2337,8 +2361,28 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
         sub = subdir_map.get(datatype, '*')
         idx_str = str(item_index)
 
-        # 精确文件名 + size 严格匹配（datatitle 可能含 glob 元字符，必须 escape）
-        if datatitle:
+        # datatype=2 图片走 flat 文件命名 (Img/0_t / Img/0 / Img/0.{ext})，
+        # 不像文件类的 F/{idx}/{filename}。Codex round-7 medium #2 实测纠正。
+        if datatype == '2':
+            flat_patterns = [
+                f"{idx_str}_t",
+                idx_str,
+                f"{idx_str}.*",
+                f"{idx_str}_*",
+            ]
+            for fp in flat_patterns:
+                for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, fp)):
+                    if datasize:
+                        try:
+                            if os.path.getsize(hit) != datasize:
+                                continue
+                        except OSError:
+                            continue
+                    if hit not in candidates:
+                        candidates.append(hit)
+
+        # 文件 / 视频 / 语音类: F|V|A/{idx}/{filename}
+        if datatype != '2' and datatitle:
             escaped_title = glob_mod.escape(datatitle)
             for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, escaped_title)):
                 if datasize:
@@ -2350,11 +2394,8 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
                 if hit not in candidates:
                     candidates.append(hit)
 
-        # size only 兜底：仅在 datatitle 缺失（如 datatype=2 图片缩略图无标题）时启用，
-        # 限定在 sub-dir + item_index 子树内，避免跨多个 Rec 目录混合无关 record。
-        # 不再做更宽的 cross-subdir 终极兜底——它会让不同合并卡片中同名同 size 的
-        # 文件互相 leak，silent 返回错的 record。Codex round-2 high #2。
-        if not candidates and not datatitle and datasize:
+        # size only 兜底：仅在 datatitle 缺失且非 image（image 已上面处理）时启用
+        if not candidates and not datatitle and datasize and datatype != '2':
             for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, '*')):
                 try:
                     if os.path.getsize(hit) == datasize:
@@ -2391,53 +2432,64 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
             + f"\n请通过其他途径区分（人工 inspect mtime 或匹配上下文）"
         )
 
+    # 威胁模型：本工具是用户主动通过 MCP 调用 + path 只在本地显示。
+    # 跟 decode_file_message 一致路线：有 md5 强校验，没 md5 fallback 到
+    # heuristic + warning（实用 over 严格）。
     cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
-    # 没 fullmd5 = 没法 cryptographic 证明候选属于该 record → fail closed。
-    # Codex round-6 high #2: candidates==1 时 ⚠️ warning 不能阻止下游使用错路径。
-    if not (expected_md5 and len(expected_md5) == 32):
+    md5_verified = False
+    if expected_md5 and len(expected_md5) == 32:
+        md5_match = []
+        md5_errors = []
+        for c in candidates:
+            if not _path_under_root(c, cache_root):
+                md5_errors.append(f"{c}: 不在 {cache_root} 下，跳过")
+                continue
+            actual_md5, err = _md5_file_chunked(c)
+            if err:
+                md5_errors.append(f"{c}: {err}")
+                continue
+            if actual_md5 == expected_md5:
+                md5_match.append(c)
+        if not md5_match:
+            info = (
+                f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
+                f"  期望 md5: {expected_md5}\n"
+                f"  说明：候选 {len(candidates)} 个，md5 都不对。"
+                f"目标 dataitem 可能未在 wechat 客户端点开过，请点击第 {item_index + 1} 项触发下载。"
+            )
+            if md5_errors:
+                info += "\n  校验异常：\n    " + "\n    ".join(md5_errors)
+            return info
+        candidates = md5_match
+        md5_verified = True
+
+    # 没 fullmd5 时多 candidates 仍 fail-closed
+    if len(candidates) > 1 and not md5_verified:
         from datetime import datetime as _dt
         details = []
-        for c in candidates[:5]:
+        for c in candidates:
             try:
                 mt = _dt.fromtimestamp(os.path.getmtime(c)).isoformat()
             except OSError:
                 mt = '?'
             details.append(f"{c} (mtime={mt})")
-        more = "" if len(candidates) <= 5 else f"\n  …还有 {len(candidates) - 5} 个候选"
         return (
-            f"该 dataitem XML 没含 fullmd5 字段，本工具拒绝基于"
-            f" (item_index+filename+size) 启发式返回路径\n"
-            f"（避免 silent 返回同 chat 内别条 record 的同名同 size 文件）:\n  "
+            f"找到 {len(candidates)} 个匹配的本地副本，无法唯一定位"
+            f"（同位置同名同 size 多份，且 dataitem XML 没含 fullmd5 用于强校验）:\n  "
             + '\n  '.join(details)
-            + more
-            + f"\n如确实需要，请人工 inspect 候选并直接 Read 你认可的 path"
+            + f"\n请人工 inspect mtime / 上下文区分"
         )
 
-    # md5 过滤候选
-    md5_match = []
-    md5_errors = []
-    for c in candidates:
-        if not _path_under_root(c, cache_root):
-            md5_errors.append(f"{c}: 不在 {cache_root} 下，跳过")
-            continue
-        actual_md5, err = _md5_file_chunked(c)
-        if err:
-            md5_errors.append(f"{c}: {err}")
-            continue
-        if actual_md5 == expected_md5:
-            md5_match.append(c)
-    if not md5_match:
-        info = (
-            f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
-            f"  期望 md5: {expected_md5}\n"
-            f"  说明：候选 {len(candidates)} 个，md5 都不对。"
-            f"目标 dataitem 可能未在 wechat 客户端点开过，请点击第 {item_index + 1} 项触发下载。"
-        )
-        if md5_errors:
-            info += "\n  校验异常：\n    " + "\n    ".join(md5_errors)
-        return info
+    chosen = candidates[0]
+    if not _path_under_root(chosen, cache_root):
+        return f"匹配到的路径 {chosen!r} 不在 {cache_root} 下，拒绝返回（可能是 symlink 攻击）"
 
-    chosen = md5_match[0]
+    binding_note = (
+        "✅ md5 校验通过，路径与 dataitem 唯一绑定"
+        if md5_verified else
+        f"⚠️  此 dataitem XML 没含 fullmd5，路径基于 (item_index+filename+size) 启发式匹配——"
+        f"如果同 chat 内多条合并卡片碰巧含同位置同名同 size 的文件，可能返回别条 record 的副本，请人工验证。"
+    )
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
@@ -2445,7 +2497,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
         f"  期望大小: {datasize:,} bytes\n"
         f"  发送者: {sourcename}\n"
         f"  类型: [{type_label}] {datatitle or '(无标题)'}\n"
-        f"  ✅ md5 校验通过，路径与 dataitem 唯一绑定"
+        f"  {binding_note}"
     )
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -566,7 +566,7 @@ def _parse_xml_root(content):
 
 
 # 合并转发的 recorditem 内嵌 XML 在 dataitem 数量多时显著超过 20K，
-# 实测含 99 条 dataitem 的卡片可达 ~50KB，用更宽的上限专门解析。
+# 实测含 99 条 dataitem 的卡片可达 ~418KB，用更宽的上限专门解析。
 _RECORD_XML_PARSE_MAX_LEN = 500_000
 
 
@@ -1848,14 +1848,14 @@ def decode_file_message(chat_name: str, local_id: int) -> str:
 
     with closing(sqlite3.connect(db_path)) as conn:
         row = conn.execute(
-            f"SELECT local_type, message_content, WCDB_CT_message_content "
+            f"SELECT local_type, create_time, message_content, WCDB_CT_message_content "
             f"FROM [{table_name}] WHERE local_id=?",
             (local_id,)
         ).fetchone()
     if not row:
         return f"找不到 local_id={local_id} 的消息"
 
-    local_type, content, ct_compress = row
+    local_type, create_time, content, ct_compress = row
     base_type, _ = _split_msg_type(local_type)
     if base_type != 49:
         return (
@@ -1886,28 +1886,57 @@ def decode_file_message(chat_name: str, local_id: int) -> str:
     if not title:
         return "消息中没有文件名 (title)"
 
+    # 性能优化：先按消息时间精确定位 msg/file/{YYYY-MM}/，命中即返回；
+    # 否则才退回 walk 全盘 os.walk（msg/attach 含数十万小文件，全盘扫描可达数秒）
+    import glob as glob_mod
     candidates = []
-    for sub_dir in ('msg/file', 'msg/attach'):
-        d = os.path.join(WECHAT_BASE_DIR, sub_dir)
-        if not os.path.isdir(d):
-            continue
-        for root_dir, _, files in os.walk(d):
-            for f in files:
-                if f.startswith('.'):
-                    continue
-                full = os.path.join(root_dir, f)
-                if f == title:
-                    candidates.append(full)
-                    continue
-                # 处理同名重复加 (1)(2) 后缀，按 size 二次确认
-                if totallen:
-                    try:
-                        if os.path.getsize(full) == totallen:
-                            stem = os.path.splitext(title)[0]
-                            if stem and stem in f:
-                                candidates.append(full)
-                    except OSError:
-                        pass
+    msg_file_dir = os.path.join(WECHAT_BASE_DIR, 'msg/file')
+    if create_time and os.path.isdir(msg_file_dir):
+        # 同名文件可能落到收到消息的当月、上一月或下一月（罕见跨月边界）
+        from datetime import datetime as _dt, timedelta as _td
+        ts_dt = _dt.fromtimestamp(create_time)
+        candidate_months = {
+            ts_dt.strftime('%Y-%m'),
+            (ts_dt - _td(days=31)).strftime('%Y-%m'),
+            (ts_dt + _td(days=31)).strftime('%Y-%m'),
+        }
+        escaped_stem = glob_mod.escape(os.path.splitext(title)[0])
+        ext = os.path.splitext(title)[1]
+        for ym in candidate_months:
+            month_dir = os.path.join(msg_file_dir, ym)
+            if not os.path.isdir(month_dir):
+                continue
+            # 精确匹配 + 同名 (1)(2) 后缀变体
+            for pattern in (
+                glob_mod.escape(title),
+                f"{escaped_stem}*{glob_mod.escape(ext)}" if ext else f"{escaped_stem}*",
+            ):
+                for hit in glob_mod.glob(os.path.join(month_dir, pattern)):
+                    if hit not in candidates:
+                        candidates.append(hit)
+
+    # 退路：未命中或没 create_time 时全盘 walk（slow path，保留原始行为兜底）
+    if not candidates:
+        for sub_dir in ('msg/file', 'msg/attach'):
+            d = os.path.join(WECHAT_BASE_DIR, sub_dir)
+            if not os.path.isdir(d):
+                continue
+            for root_dir, _, files in os.walk(d):
+                for f in files:
+                    if f.startswith('.'):
+                        continue
+                    full = os.path.join(root_dir, f)
+                    if f == title:
+                        candidates.append(full)
+                        continue
+                    if totallen:
+                        try:
+                            if os.path.getsize(full) == totallen:
+                                stem = os.path.splitext(title)[0]
+                                if stem and stem in f:
+                                    candidates.append(full)
+                        except OSError:
+                            pass
 
     if not candidates:
         return (
@@ -1979,7 +2008,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
         return f"找不到 local_id={local_id} 的消息"
 
     local_type, content, ct_compress = row
-    base_type, sub_type_packed = _split_msg_type(local_type)
+    base_type, _ = _split_msg_type(local_type)
     if base_type != 49:
         return (
             f"不是合并转发消息（local_type={local_type}, base_type={base_type}），"
@@ -2033,7 +2062,8 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
         '1': '文本', '2': '图片', '3': '名片', '4': '语音',
         '5': '视频', '6': '链接', '7': '位置', '8': '文件',
         '17': '聊天记录', '19': '小程序', '22': '视频号',
-        '29': '音乐', '37': '表情包',
+        '23': '视频号直播', '29': '音乐', '36': '小程序/H5',
+        '37': '表情包',
     }.get(datatype, f'datatype={datatype}')
 
     if datatype == '1':

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2081,29 +2081,32 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                     if hit not in candidates:
                         candidates.append(hit)
 
-    # 退路：未命中或没 create_time 时只 walk msg/file（slow path 兜底）
-    # 不再扫 msg/attach —— 那是合并卡片/图片的缓存目录，外层文件不应该出现在那。
-    # Codex round-5 high #1：之前扫 msg/attach 会让另一条合并 record 里的同名同 size
-    # 文件被当作目标，silent 返回错副本。
+    # 退路：未命中或没 create_time 时只 walk msg/file（slow path 兜底）。
+    # 文件名匹配严格化：只接受精确匹配或 wechat 自动加副本的 "(N)" 后缀变体
+    # （round-8 high #1：之前用 `stem in f` 子串匹配会把"某某论文.pdf"当成 "论文.pdf"）。
     if not candidates:
         d = os.path.join(WECHAT_BASE_DIR, 'msg/file')
+        stem, ext = os.path.splitext(title)
+        copy_pattern = re.compile(
+            r'^' + re.escape(stem) + r' ?\(\d+\)' + re.escape(ext) + r'$'
+        )
         if os.path.isdir(d):
             for root_dir, _, files in os.walk(d):
                 for f in files:
                     if f.startswith('.'):
                         continue
                     full = os.path.join(root_dir, f)
-                    if f == title:
-                        candidates.append(full)
+                    is_exact = (f == title)
+                    is_copy_variant = bool(copy_pattern.match(f))
+                    if not (is_exact or is_copy_variant):
                         continue
                     if totallen:
                         try:
-                            if os.path.getsize(full) == totallen:
-                                stem = os.path.splitext(title)[0]
-                                if stem and stem in f:
-                                    candidates.append(full)
+                            if os.path.getsize(full) != totallen:
+                                continue
                         except OSError:
-                            pass
+                            continue
+                    candidates.append(full)
 
     if not candidates:
         return (
@@ -2413,25 +2416,8 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
             f"  解决方法: 在 wechat 客户端打开此合并记录卡片，点击第 {item_index + 1} 项让客户端下载，再试"
         )
 
-    # Fail closed：多 candidates 时报歧义而不是 silent 选 mtime 最新。
-    # 不同合并卡片可能在 wechat 缓存里产生同 (filename, size, item_index) 的副本，
-    # 用 mtime 选最新会让用户拿到非自己 local_id 对应的 record 的文件。
-    if len(candidates) > 1:
-        from datetime import datetime as _dt
-        details = []
-        for c in candidates:
-            try:
-                mt = _dt.fromtimestamp(os.path.getmtime(c)).isoformat()
-            except OSError:
-                mt = '?'
-            details.append(f"{c} (mtime={mt})")
-        return (
-            f"找到 {len(candidates)} 个匹配的本地副本，无法唯一定位（可能其他合并卡片"
-            f"也含同名同 size 的同位置 dataitem）:\n  "
-            + '\n  '.join(details)
-            + f"\n请通过其他途径区分（人工 inspect mtime 或匹配上下文）"
-        )
-
+    # 注意：早 ambiguity check（在 md5 filter 之前）已经被删除——它会让有 fullmd5
+    # 但多 candidates 的合理 case silent 失败。md5 filter 后再做歧义判断（见下方）。
     # 威胁模型：本工具是用户主动通过 MCP 调用 + path 只在本地显示。
     # 跟 decode_file_message 一致路线：有 md5 强校验，没 md5 fallback 到
     # heuristic + warning（实用 over 严格）。

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -610,6 +610,9 @@ def _format_app_message_text(content, local_type, is_group, chat_username, chat_
             quote_text += f"\n  ↳ {prefix}{ref_content}"
         return quote_text
 
+    if app_type == 19:
+        return _format_record_message_text(appmsg, title)
+
     if app_type == 6:
         return f"[文件] {title}" if title else "[文件]"
     if app_type == 5:
@@ -619,6 +622,106 @@ def _format_app_message_text(content, local_type, is_group, chat_username, chat_
     if title:
         return f"[链接/文件] {title}"
     return "[链接/文件]"
+
+
+_RECORD_MAX_ITEMS = 50
+_RECORD_MAX_LINE_LEN = 200
+
+
+def _format_record_dataitem(item):
+    """格式化合并记录中的单个 dataitem，返回展示文本。"""
+    datatype = (item.get('datatype') or '').strip()
+
+    if datatype == '1':
+        return _collapse_text(item.findtext('datadesc') or '') or '[文本]'
+    if datatype == '2':
+        return '[图片]'
+    if datatype == '3':
+        return '[名片]'
+    if datatype == '4':
+        return '[语音]'
+    if datatype == '5':
+        return '[视频]'
+    if datatype == '6':
+        link_title = _collapse_text(item.findtext('datatitle') or '')
+        return f"[链接] {link_title}" if link_title else '[链接]'
+    if datatype == '7':
+        return '[位置]'
+    if datatype == '8':
+        file_title = _collapse_text(item.findtext('datatitle') or '')
+        return f"[文件] {file_title}" if file_title else '[文件]'
+    if datatype == '17':
+        nested_title = _collapse_text(item.findtext('datatitle') or '')
+        return f"[聊天记录] {nested_title}" if nested_title else '[聊天记录]'
+    if datatype == '19':
+        app_name = _collapse_text(item.findtext('.//appbranditem/sourcedisplayname') or '')
+        item_title = _collapse_text(item.findtext('datatitle') or '')
+        label = item_title or app_name or '小程序'
+        return f"[小程序] {label}"
+    if datatype == '22':
+        feed_desc = _collapse_text(item.findtext('.//finderFeed/desc') or '')
+        return f"[视频号] {feed_desc[:80]}" if feed_desc else '[视频号]'
+    if datatype == '23':
+        return '[视频号直播]'
+    if datatype == '29':
+        song = _collapse_text(item.findtext('datatitle') or '')
+        artist = _collapse_text(item.findtext('datadesc') or '')
+        if song and artist:
+            return f"[音乐] {song} - {artist}"
+        return f"[音乐] {song}" if song else '[音乐]'
+    if datatype == '36':
+        link_title = _collapse_text(item.findtext('datatitle') or '')
+        return f"[小程序/H5] {link_title}" if link_title else '[小程序/H5]'
+    if datatype == '37':
+        return '[表情包]'
+
+    desc = _collapse_text(item.findtext('datadesc') or '')
+    title_text = _collapse_text(item.findtext('datatitle') or '')
+    fallback = desc or title_text
+    return fallback if fallback else f"[未知类型 {datatype}]"
+
+
+def _format_record_message_text(appmsg, title):
+    """解析合并转发的聊天记录卡片（appmsg type=19, recorditem）。"""
+    fallback_title = title or '聊天记录'
+    record_node = appmsg.find('recorditem')
+    if record_node is None or not record_node.text:
+        return f"[聊天记录] {fallback_title}（待加载）"
+
+    inner = _parse_xml_root(record_node.text)
+    if inner is None:
+        return f"[聊天记录] {fallback_title}"
+
+    record_title = _collapse_text(inner.findtext('title') or '') or fallback_title
+    is_chatroom = (inner.findtext('isChatRoom') or '').strip() == '1'
+    datalist = inner.find('datalist')
+    items = list(datalist.findall('dataitem')) if datalist is not None else []
+    if not items:
+        suffix = "（群聊转发，待加载）" if is_chatroom else "（待加载）"
+        return f"[聊天记录] {record_title}{suffix}"
+
+    header = f"[聊天记录] {record_title}"
+    if is_chatroom:
+        header += "（群聊转发）"
+    header += f"，共 {len(items)} 条"
+
+    lines = [header + ":"]
+    for item in items[:_RECORD_MAX_ITEMS]:
+        sender = _collapse_text(item.findtext('sourcename') or '')
+        when = _collapse_text(item.findtext('sourcetime') or '')
+        content = _format_record_dataitem(item)
+
+        if len(content) > _RECORD_MAX_LINE_LEN:
+            content = content[:_RECORD_MAX_LINE_LEN] + '…'
+
+        prefix_parts = [p for p in (when, sender) if p]
+        prefix = ' '.join(prefix_parts)
+        lines.append(f"  {prefix}: {content}" if prefix else f"  {content}")
+
+    if len(items) > _RECORD_MAX_ITEMS:
+        lines.append(f"  …（还有 {len(items) - _RECORD_MAX_ITEMS} 条未显示）")
+
+    return "\n".join(lines)
 
 
 def _format_voip_message_text(content):
@@ -1696,6 +1799,297 @@ def decode_image(chat_name: str, local_id: int) -> str:
         if 'md5' in result:
             error += f"\n  MD5: {result['md5']}"
         return f"解密失败: {error}"
+
+
+@mcp.tool()
+def decode_file_message(chat_name: str, local_id: int) -> str:
+    """获取微信聊天中外层文件消息（PDF/docx/xlsx 等）的本地副本路径。
+
+    微信会把对方发来的文件下载到 ~/Library/.../msg/file/{YYYY-MM}/原文件名.{ext}
+    （macOS）。本工具从消息记录解析出文件名/大小，在本地缓存中精确定位，
+    然后返回原始路径，可直接交给 Read/PDF 工具读取。
+
+    使用流程：先用 get_chat_history 找到 [文件] xxx.pdf 类消息的 local_id，
+    再用本工具拿到本地路径。
+
+    Args:
+        chat_name: 聊天对象的名字、备注名或wxid
+        local_id: 文件消息的 local_id（从 get_chat_history 获取）
+    """
+    try:
+        local_id = int(local_id)
+    except (TypeError, ValueError):
+        return "错误: local_id 必须是整数"
+
+    username = resolve_username(chat_name)
+    if not username:
+        return f"找不到聊天对象: {chat_name}"
+
+    db_path, table_name = _find_msg_table_for_user(username)
+    if not db_path or not table_name:
+        return f"找不到 {chat_name} 的消息表"
+    if not _is_safe_msg_table_name(table_name):
+        return f"非法消息表名: {table_name}"
+
+    with closing(sqlite3.connect(db_path)) as conn:
+        row = conn.execute(
+            f"SELECT local_type, message_content, WCDB_CT_message_content "
+            f"FROM [{table_name}] WHERE local_id=?",
+            (local_id,)
+        ).fetchone()
+    if not row:
+        return f"找不到 local_id={local_id} 的消息"
+
+    local_type, content, ct_compress = row
+    base_type, _ = _split_msg_type(local_type)
+    if base_type != 49:
+        return (
+            f"不是文件消息（local_type={local_type}，base_type={base_type}），"
+            f"文件消息应为 base_type=49 且 sub_type=6"
+        )
+
+    xml_text = _decompress_content(content, ct_compress)
+    if not xml_text:
+        return "消息 content 为空或无法解码"
+
+    # 剥离群聊 sender 前缀 "wxid_xxx:\n<xml...>"
+    if '<appmsg' in xml_text and ':\n' in xml_text and not xml_text.lstrip().startswith('<'):
+        xml_text = xml_text.split(':\n', 1)[1]
+
+    root = _parse_xml_root(xml_text)
+    if root is None:
+        return "无法解析消息 XML"
+
+    appmsg = root.find('.//appmsg')
+    if appmsg is None:
+        return "消息中没有 appmsg 段（可能不是文件类型）"
+
+    title = _collapse_text(appmsg.findtext('title') or '')
+    fileext = _collapse_text(appmsg.findtext('.//fileext') or '')
+    totallen = _parse_int(_collapse_text(appmsg.findtext('.//totallen') or ''), 0)
+
+    if not title:
+        return "消息中没有文件名 (title)"
+
+    candidates = []
+    for sub_dir in ('msg/file', 'msg/attach'):
+        d = os.path.join(WECHAT_BASE_DIR, sub_dir)
+        if not os.path.isdir(d):
+            continue
+        for root_dir, _, files in os.walk(d):
+            for f in files:
+                if f.startswith('.'):
+                    continue
+                full = os.path.join(root_dir, f)
+                if f == title:
+                    candidates.append(full)
+                    continue
+                # 处理同名重复加 (1)(2) 后缀，按 size 二次确认
+                if totallen:
+                    try:
+                        if os.path.getsize(full) == totallen:
+                            stem = os.path.splitext(title)[0]
+                            if stem and stem in f:
+                                candidates.append(full)
+                    except OSError:
+                        pass
+
+    if not candidates:
+        return (
+            f"在本地缓存中找不到 {title}\n"
+            f"  期望路径模式: {WECHAT_BASE_DIR}/msg/file/YYYY-MM/{title}\n"
+            f"  可能原因：从未在 PC/Mac 微信打开过 / 已被清理"
+        )
+
+    # 优先取 size 完全匹配的；并按 mtime 最近排序
+    size_match = [c for c in candidates if totallen and os.path.getsize(c) == totallen]
+    if size_match:
+        candidates = size_match
+    candidates.sort(key=lambda p: -os.path.getmtime(p))
+    chosen = candidates[0]
+
+    extra = ""
+    if len(candidates) > 1:
+        extra = f"\n  其他候选: {len(candidates) - 1} 个"
+    return (
+        f"找到本地文件:\n"
+        f"  路径: {chosen}\n"
+        f"  大小: {os.path.getsize(chosen):,} bytes\n"
+        f"  扩展名: {fileext or os.path.splitext(title)[1].lstrip('.') or '?'}\n"
+        f"  期望大小: {totallen:,} bytes" + extra
+    )
+
+
+@mcp.tool()
+def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
+    """获取合并转发聊天记录中某个内嵌文件/图片的本地副本路径。
+
+    使用流程：
+    1. 先用 get_chat_history 找到 [聊天记录] xxx 卡片，记下其 local_id 以及要的
+       dataitem 在 datalist 里的位置（0-based，第一条 = 0）
+    2. 用本工具拿本地路径
+    3. 如果未下载，工具会精确告诉你去 wechat 客户端点击合并卡片里的第几项触发下载
+
+    注意：合并转发里的内嵌文件只有在用户**点击查看**后 wechat 才会下载到本地。
+    没点过的 dataitem 用本工具会得到"未下载"提示。
+
+    Args:
+        chat_name: 聊天对象的名字、备注名或wxid
+        local_id: 合并转发消息（带"[聊天记录]"标记）的 local_id
+        item_index: dataitem 在 datalist 里的 0-based 索引
+    """
+    try:
+        local_id = int(local_id)
+        item_index = int(item_index)
+    except (TypeError, ValueError):
+        return "错误: local_id 和 item_index 必须是整数"
+
+    username = resolve_username(chat_name)
+    if not username:
+        return f"找不到聊天对象: {chat_name}"
+
+    db_path, table_name = _find_msg_table_for_user(username)
+    if not db_path or not table_name:
+        return f"找不到 {chat_name} 的消息表"
+    if not _is_safe_msg_table_name(table_name):
+        return f"非法消息表名: {table_name}"
+
+    with closing(sqlite3.connect(db_path)) as conn:
+        row = conn.execute(
+            f"SELECT local_type, message_content, WCDB_CT_message_content "
+            f"FROM [{table_name}] WHERE local_id=?",
+            (local_id,)
+        ).fetchone()
+    if not row:
+        return f"找不到 local_id={local_id} 的消息"
+
+    local_type, content, ct_compress = row
+    base_type, sub_type_packed = _split_msg_type(local_type)
+    if base_type != 49:
+        return (
+            f"不是合并转发消息（local_type={local_type}, base_type={base_type}），"
+            f"合并转发应为 base_type=49 + appmsg type=19"
+        )
+
+    xml_text = _decompress_content(content, ct_compress)
+    if not xml_text:
+        return "消息 content 为空或无法解码"
+
+    if '<appmsg' in xml_text and ':\n' in xml_text and not xml_text.lstrip().startswith('<'):
+        xml_text = xml_text.split(':\n', 1)[1]
+
+    root = _parse_xml_root(xml_text)
+    if root is None:
+        return "无法解析消息 XML（可能不是合并转发消息）"
+    appmsg = root.find('.//appmsg')
+    if appmsg is None:
+        return "消息中没有 appmsg 段"
+
+    app_type = _parse_int(_collapse_text(appmsg.findtext('type') or ''), 0)
+    if app_type != 19:
+        return (
+            f"不是合并转发消息（appmsg type={app_type}），"
+            f"合并转发应为 type=19。请用 decode_file_message 处理外层独立文件"
+        )
+
+    record_node = appmsg.find('recorditem')
+    if record_node is None or not record_node.text:
+        return "消息中没有 recorditem（datalist 还未加载，请在 wechat 中点开此卡片让客户端拉取）"
+
+    inner = _parse_xml_root(record_node.text)
+    if inner is None:
+        return "无法解析 recorditem 内嵌 XML"
+
+    datalist = inner.find('datalist')
+    items = list(datalist.findall('dataitem')) if datalist is not None else []
+    if not items:
+        return "datalist 为空（合并记录还未加载内容）"
+    if item_index < 0 or item_index >= len(items):
+        return f"item_index={item_index} 超出范围（共 {len(items)} 条 dataitem，0-based）"
+
+    item = items[item_index]
+    datatype = (item.get('datatype') or '').strip()
+    datatitle = _collapse_text(item.findtext('datatitle') or '')
+    datasize = _parse_int(_collapse_text(item.findtext('datasize') or ''), 0)
+    datafmt = _collapse_text(item.findtext('datafmt') or '')
+    sourcename = _collapse_text(item.findtext('sourcename') or '')
+
+    type_label = {
+        '1': '文本', '2': '图片', '3': '名片', '4': '语音',
+        '5': '视频', '6': '链接', '7': '位置', '8': '文件',
+        '17': '聊天记录', '19': '小程序', '22': '视频号',
+        '29': '音乐', '37': '表情包',
+    }.get(datatype, f'datatype={datatype}')
+
+    if datatype == '1':
+        text_content = _collapse_text(item.findtext('datadesc') or '')
+        return (
+            f"该 dataitem 是文本，无需下载:\n"
+            f"  发送者: {sourcename}\n"
+            f"  内容: {text_content}"
+        )
+
+    table_hash = table_name.replace('Msg_', '', 1)
+    attach_dir = os.path.join(WECHAT_BASE_DIR, 'msg/attach', table_hash)
+
+    candidates = []
+    if os.path.isdir(attach_dir):
+        import glob as glob_mod
+        # 文件类（datatype=8）落 F/{idx}/，图片类落 Img/{idx}/，视频类落 V/{idx}/
+        subdir_map = {'8': 'F', '2': 'Img', '5': 'V', '4': 'A'}
+        sub = subdir_map.get(datatype, '*')
+        idx_str = str(item_index)
+
+        # 精确文件名匹配
+        if datatitle:
+            for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, datatitle)):
+                if hit not in candidates:
+                    candidates.append(hit)
+
+        # size 兜底匹配（任何文件名）
+        if not candidates and datasize:
+            for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, '*')):
+                try:
+                    if os.path.getsize(hit) == datasize:
+                        candidates.append(hit)
+                except OSError:
+                    pass
+
+        # 终极兜底：不限定 sub 目录
+        if not candidates and datasize:
+            for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*/*', idx_str, '*')):
+                try:
+                    if os.path.getsize(hit) == datasize:
+                        candidates.append(hit)
+                except OSError:
+                    pass
+
+    if not candidates:
+        return (
+            f"在本地缓存中找不到此 dataitem（很可能未在 wechat 客户端点击查看过）\n"
+            f"  消息: {chat_name} 的 local_id={local_id}\n"
+            f"  dataitem[{item_index}]: {sourcename}: [{type_label}] {datatitle or '(无标题)'}\n"
+            f"  期望大小: {datasize:,} bytes\n"
+            f"  期望路径模式: {attach_dir}/YYYY-MM/Rec/*/{subdir_map.get(datatype, '?')}/{item_index}/{datatitle}\n"
+            f"  解决方法: 在 wechat 客户端打开此合并记录卡片，点击第 {item_index + 1} 项让客户端下载，再试"
+        )
+
+    if datasize:
+        size_match = [c for c in candidates if os.path.getsize(c) == datasize]
+        if size_match:
+            candidates = size_match
+    candidates.sort(key=lambda p: -os.path.getmtime(p))
+    chosen = candidates[0]
+
+    extra = f"\n  其他候选: {len(candidates) - 1} 个" if len(candidates) > 1 else ""
+    return (
+        f"找到本地文件:\n"
+        f"  路径: {chosen}\n"
+        f"  大小: {os.path.getsize(chosen):,} bytes\n"
+        f"  期望大小: {datasize:,} bytes\n"
+        f"  发送者: {sourcename}\n"
+        f"  类型: [{type_label}] {datatitle or '(无标题)'}" + extra
+    )
 
 
 @mcp.tool()

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -577,17 +577,23 @@ def _parse_int(value, fallback=0):
         return fallback
 
 
+def _parse_app_message_outer(content):
+    """Parse outer appmsg XML，自动在 default 20K 上限拒绝时用 _RECORD_XML_PARSE_MAX_LEN
+    重试。这是因为 type=19 合并转发卡片的 outer XML 可超 20K，所有解析 outer appmsg
+    的 caller（get_chat_history 渲染 / decode_file_message / decode_record_item）都
+    必须共用此宽容路径，否则同一条大消息在不同 caller 上行为不一致。"""
+    root = _parse_xml_root(content)
+    if root is None and content and len(content) <= _RECORD_XML_PARSE_MAX_LEN:
+        root = _parse_xml_root(content, max_len=_RECORD_XML_PARSE_MAX_LEN)
+    return root
+
+
 def _format_app_message_text(content, local_type, is_group, chat_username, chat_display_name, names):
     if not content or '<appmsg' not in content:
         return None
 
     _, sub_type = _split_msg_type(local_type)
-    root = _parse_xml_root(content)
-    if root is None and len(content) <= _RECORD_XML_PARSE_MAX_LEN:
-        # type=19 合并转发卡片 outer XML 可超过默认 20K，必要时用更宽上限重试，
-        # 否则展开链 _format_record_message_text → _parse_xml_root(record_node.text)
-        # 永远到不了，大合并消息会静默退化为 [链接/文件]。
-        root = _parse_xml_root(content, max_len=_RECORD_XML_PARSE_MAX_LEN)
+    root = _parse_app_message_outer(content)
     if root is None:
         return None
 
@@ -1919,7 +1925,7 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
     is_group = username.endswith('@chatroom')
     _, xml_text = _parse_message_content(xml_text, local_type, is_group)
 
-    root = _parse_xml_root(xml_text)
+    root = _parse_app_message_outer(xml_text)
     if root is None:
         return "无法解析消息 XML"
 
@@ -2121,7 +2127,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
     is_group = username.endswith('@chatroom')
     _, xml_text = _parse_message_content(xml_text, local_type, is_group)
 
-    root = _parse_xml_root(xml_text)
+    root = _parse_app_message_outer(xml_text)
     if root is None:
         return "无法解析消息 XML（可能不是合并转发消息）"
     appmsg = root.find('.//appmsg')
@@ -2186,12 +2192,10 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
         sub = subdir_map.get(datatype, '*')
         idx_str = str(item_index)
 
-        # 精确文件名匹配（datatitle 可能含 [ ] * ? 等 glob 元字符，必须 escape）
+        # 精确文件名 + size 严格匹配（datatitle 可能含 glob 元字符，必须 escape）
         if datatitle:
             escaped_title = glob_mod.escape(datatitle)
             for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, escaped_title)):
-                # 有 datasize 时立刻 size 验证：避免命中"同名但 size 不对"的副本
-                # 阻塞兜底匹配，最终返回错误文件
                 if datasize:
                     try:
                         if os.path.getsize(hit) != datasize:
@@ -2201,18 +2205,12 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
                 if hit not in candidates:
                     candidates.append(hit)
 
-        # size 兜底匹配（任何文件名）
-        if not candidates and datasize:
+        # size only 兜底：仅在 datatitle 缺失（如 datatype=2 图片缩略图无标题）时启用，
+        # 限定在 sub-dir + item_index 子树内，避免跨多个 Rec 目录混合无关 record。
+        # 不再做更宽的 cross-subdir 终极兜底——它会让不同合并卡片中同名同 size 的
+        # 文件互相 leak，silent 返回错的 record。Codex round-2 high #2。
+        if not candidates and not datatitle and datasize:
             for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, '*')):
-                try:
-                    if os.path.getsize(hit) == datasize:
-                        candidates.append(hit)
-                except OSError:
-                    pass
-
-        # 终极兜底：不限定 sub 目录
-        if not candidates and datasize:
-            for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*/*', idx_str, '*')):
                 try:
                     if os.path.getsize(hit) == datasize:
                         candidates.append(hit)
@@ -2229,21 +2227,33 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
             f"  解决方法: 在 wechat 客户端打开此合并记录卡片，点击第 {item_index + 1} 项让客户端下载，再试"
         )
 
-    if datasize:
-        size_match = [c for c in candidates if os.path.getsize(c) == datasize]
-        if size_match:
-            candidates = size_match
-    candidates.sort(key=lambda p: -os.path.getmtime(p))
-    chosen = candidates[0]
+    # Fail closed：多 candidates 时报歧义而不是 silent 选 mtime 最新。
+    # 不同合并卡片可能在 wechat 缓存里产生同 (filename, size, item_index) 的副本，
+    # 用 mtime 选最新会让用户拿到非自己 local_id 对应的 record 的文件。
+    if len(candidates) > 1:
+        from datetime import datetime as _dt
+        details = []
+        for c in candidates:
+            try:
+                mt = _dt.fromtimestamp(os.path.getmtime(c)).isoformat()
+            except OSError:
+                mt = '?'
+            details.append(f"{c} (mtime={mt})")
+        return (
+            f"找到 {len(candidates)} 个匹配的本地副本，无法唯一定位（可能其他合并卡片"
+            f"也含同名同 size 的同位置 dataitem）:\n  "
+            + '\n  '.join(details)
+            + f"\n请通过其他途径区分（人工 inspect mtime 或匹配上下文）"
+        )
 
-    extra = f"\n  其他候选: {len(candidates) - 1} 个" if len(candidates) > 1 else ""
+    chosen = candidates[0]
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
         f"  大小: {os.path.getsize(chosen):,} bytes\n"
         f"  期望大小: {datasize:,} bytes\n"
         f"  发送者: {sourcename}\n"
-        f"  类型: [{type_label}] {datatitle or '(无标题)'}" + extra
+        f"  类型: [{type_label}] {datatitle or '(无标题)'}"
     )
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -7,10 +7,11 @@ Runs on Windows Python (needs access to D:\ WeChat databases).
 
 import io
 import os, sys, json, time, sqlite3, tempfile, struct, hashlib, atexit, re, threading
+import glob
 import wave
 import hmac as hmac_mod
 from contextlib import closing
-from datetime import datetime
+from datetime import datetime, timedelta
 import xml.etree.ElementTree as ET
 from Crypto.Cipher import AES
 from mcp.server.fastmcp import FastMCP
@@ -451,9 +452,8 @@ def _decompress_content(content, ct):
 def _parse_message_content(content, local_type, is_group):
     """解析消息内容，返回 (sender_id, text)。
 
-    群消息 content 形如 'wxid_xxx:\n<xml...>'；但 Codex round-7 实测发现
-    部分 type=19 合并转发也会写成 'wxid_xxx:<?xml...' 或 'wxid_xxx:<msg...'
-    不带换行 → 必须扩展剥离逻辑。
+    群消息 content 形如 'wxid_xxx:\n<xml...>'；某些 type=19 合并转发也会
+    写成 'wxid_xxx:<?xml...' 或 'wxid_xxx:<msg...' 不带换行——剥离逻辑两种都要处理。
     """
     if content is None:
         return '', ''
@@ -575,9 +575,8 @@ _RECORD_XML_PARSE_MAX_LEN = 500_000
 def _safe_basename(name):
     """对 user-derived filename（从消息 XML 来，不可信）做严格 sanitize。
 
-    Codex adversarial round 4 建议"reject suspicious input"而不是 normalize：
-    哪怕 os.path.basename 把 '../foo' 剥成 'foo' 是 safe 的，意图依然可疑，
-    应该让工具显式失败让用户看到，而不是默默 normalize 接受。
+    Reject 而不是 normalize：哪怕 os.path.basename 把 '../foo' 剥成 'foo' 是
+    safe 的，意图依然可疑，应该显式失败让用户看到。
     """
     if not name:
         return ''
@@ -618,14 +617,13 @@ def _md5_file_chunked(path, max_size=_MD5_VERIFY_MAX_SIZE):
     超过 max_size 直接拒绝（DoS 防御 + 大附件 md5 校验现实意义不大）。
     返回 (md5_hex, error)；成功时 error 为 None。
     """
-    import hashlib as _hashlib
     try:
         size = os.path.getsize(path)
     except OSError as e:
         return None, f"无法读取文件 size: {e}"
     if size > max_size:
         return None, f"文件 size {size:,} 超过 md5 校验上限 {max_size:,}（防 DoS）"
-    h = _hashlib.md5()
+    h = hashlib.md5()
     try:
         with open(path, 'rb') as f:
             while True:
@@ -656,13 +654,11 @@ def _parse_int(value, fallback=0):
 
 
 def _parse_app_message_outer(content):
-    """Parse outer appmsg XML，自动在 default 20K 上限拒绝时用 _RECORD_XML_PARSE_MAX_LEN
-    重试。这是因为 type=19 合并转发卡片的 outer XML 可超 20K，所有解析 outer appmsg
-    的 caller（get_chat_history 渲染 / decode_file_message / decode_record_item）都
-    必须共用此宽容路径，否则同一条大消息在不同 caller 上行为不一致。
+    """Parse outer appmsg XML，对 type=19 合并卡片自动放宽到 _RECORD_XML_PARSE_MAX_LEN。
 
-    Codex round-5 medium：只对**真的 type=19 合并卡片**放宽——用 substring 短路
-    避免每条非 type=19 的大 appmsg 都付出 500K parse 代价。"""
+    所有解析 outer appmsg 的 caller（get_chat_history 渲染 / decode_file_message /
+    decode_record_item）共用此 helper，避免同一条大消息在不同 caller 上行为不一致。
+    Substring 短路保证非 type=19 的大 appmsg 不付出 500K parse 代价。"""
     root = _parse_xml_root(content)
     if root is None and content and len(content) <= _RECORD_XML_PARSE_MAX_LEN:
         if '<type>19</type>' in content:
@@ -725,6 +721,20 @@ def _format_app_message_text(content, local_type, is_group, chat_username, chat_
 _RECORD_MAX_ITEMS = 50
 _RECORD_MAX_LINE_LEN = 200
 
+# 合并转发 dataitem 的 datatype → wechat 缓存子目录映射。仅这 4 类有真本地
+# binary 文件；其他 datatype（链接/名片/小程序/视频号 等）只有 metadata。
+_RECORD_BINARY_SUBDIR = {'8': 'F', '2': 'Img', '5': 'V', '4': 'A'}
+
+# datatype → 中文标签，散在多处使用：渲染合并卡片 / decode_record_item 的
+# 错误提示 / 单元测试。统一在模块顶部维护避免漂移。
+_RECORD_DATATYPE_LABEL = {
+    '1': '文本', '2': '图片', '3': '名片', '4': '语音',
+    '5': '视频', '6': '链接', '7': '位置', '8': '文件',
+    '17': '聊天记录', '19': '小程序', '22': '视频号',
+    '23': '视频号直播', '29': '音乐', '36': '小程序/H5',
+    '37': '表情包',
+}
+
 
 def _format_record_dataitem(item):
     """格式化合并记录中的单个 dataitem，返回展示文本。"""
@@ -732,19 +742,12 @@ def _format_record_dataitem(item):
 
     if datatype == '1':
         return _collapse_text(item.findtext('datadesc') or '') or '[文本]'
-    if datatype == '2':
-        return '[图片]'
-    if datatype == '3':
-        return '[名片]'
-    if datatype == '4':
-        return '[语音]'
-    if datatype == '5':
-        return '[视频]'
-    if datatype == '6':
+    if datatype in ('2', '3', '4', '5', '7', '23', '37'):
+        return f"[{_RECORD_DATATYPE_LABEL[datatype]}]"
+    if datatype in ('6', '36'):
         link_title = _collapse_text(item.findtext('datatitle') or '')
-        return f"[链接] {link_title}" if link_title else '[链接]'
-    if datatype == '7':
-        return '[位置]'
+        label = _RECORD_DATATYPE_LABEL[datatype]
+        return f"[{label}] {link_title}" if link_title else f"[{label}]"
     if datatype == '8':
         file_title = _collapse_text(item.findtext('datatitle') or '')
         return f"[文件] {file_title}" if file_title else '[文件]'
@@ -752,26 +755,20 @@ def _format_record_dataitem(item):
         nested_title = _collapse_text(item.findtext('datatitle') or '')
         return f"[聊天记录] {nested_title}" if nested_title else '[聊天记录]'
     if datatype == '19':
-        app_name = _collapse_text(item.findtext('.//appbranditem/sourcedisplayname') or '')
+        # 小程序：appbranditem/sourcedisplayname 是直接子代，不需要 .// 递归
+        app_name = _collapse_text(item.findtext('appbranditem/sourcedisplayname') or '')
         item_title = _collapse_text(item.findtext('datatitle') or '')
         label = item_title or app_name or '小程序'
         return f"[小程序] {label}"
     if datatype == '22':
-        feed_desc = _collapse_text(item.findtext('.//finderFeed/desc') or '')
+        feed_desc = _collapse_text(item.findtext('finderFeed/desc') or '')
         return f"[视频号] {feed_desc[:80]}" if feed_desc else '[视频号]'
-    if datatype == '23':
-        return '[视频号直播]'
     if datatype == '29':
         song = _collapse_text(item.findtext('datatitle') or '')
         artist = _collapse_text(item.findtext('datadesc') or '')
         if song and artist:
             return f"[音乐] {song} - {artist}"
         return f"[音乐] {song}" if song else '[音乐]'
-    if datatype == '36':
-        link_title = _collapse_text(item.findtext('datatitle') or '')
-        return f"[小程序/H5] {link_title}" if link_title else '[小程序/H5]'
-    if datatype == '37':
-        return '[表情包]'
 
     desc = _collapse_text(item.findtext('datadesc') or '')
     title_text = _collapse_text(item.findtext('datatitle') or '')
@@ -1978,11 +1975,10 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
             return f"找不到 (local_id={local_id}, create_time={create_time}) 的消息（已扫描 {len(shards)} 个分片）"
         return f"找不到 local_id={local_id} 的消息（已扫描 {len(shards)} 个分片）"
     if len(matches) > 1:
-        from datetime import datetime as _dt
         details = []
         for db_p, r in matches:
             ct = r[1]
-            ts_str = _dt.fromtimestamp(ct).isoformat() if ct else '?'
+            ts_str = datetime.fromtimestamp(ct).isoformat() if ct else '?'
             details.append(f"{os.path.basename(db_p)} create_time={ct} ({ts_str})")
         return (
             f"local_id={local_id} 在 {len(matches)} 个分片中都存在，无法唯一定位:\n  "
@@ -2046,19 +2042,17 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
 
     # 性能优化：先按消息时间精确定位 msg/file/{YYYY-MM}/，命中即返回；
     # 否则才退回 walk 全盘 os.walk（msg/attach 含数十万小文件，全盘扫描可达数秒）
-    import glob as glob_mod
     candidates = []
     msg_file_dir = os.path.join(WECHAT_BASE_DIR, 'msg/file')
     if create_time and os.path.isdir(msg_file_dir):
         # 同名文件可能落到收到消息的当月、上一月或下一月（罕见跨月边界）
-        from datetime import datetime as _dt, timedelta as _td
-        ts_dt = _dt.fromtimestamp(create_time)
+        ts_dt = datetime.fromtimestamp(create_time)
         candidate_months = {
             ts_dt.strftime('%Y-%m'),
-            (ts_dt - _td(days=31)).strftime('%Y-%m'),
-            (ts_dt + _td(days=31)).strftime('%Y-%m'),
+            (ts_dt - timedelta(days=31)).strftime('%Y-%m'),
+            (ts_dt + timedelta(days=31)).strftime('%Y-%m'),
         }
-        escaped_stem = glob_mod.escape(os.path.splitext(title)[0])
+        escaped_stem = glob.escape(os.path.splitext(title)[0])
         ext = os.path.splitext(title)[1]
         for ym in candidate_months:
             month_dir = os.path.join(msg_file_dir, ym)
@@ -2066,10 +2060,10 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                 continue
             # 精确匹配 + 同名 (1)(2) 后缀变体
             for pattern in (
-                glob_mod.escape(title),
-                f"{escaped_stem}*{glob_mod.escape(ext)}" if ext else f"{escaped_stem}*",
+                glob.escape(title),
+                f"{escaped_stem}*{glob.escape(ext)}" if ext else f"{escaped_stem}*",
             ):
-                for hit in glob_mod.glob(os.path.join(month_dir, pattern)):
+                for hit in glob.glob(os.path.join(month_dir, pattern)):
                     # 有 totallen 时立刻 size 验证：避免月扫命中"同名但 size 不对"的副本
                     # 阻塞 walk 兜底，最终返回错误文件
                     if totallen:
@@ -2082,8 +2076,8 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                         candidates.append(hit)
 
     # 退路：未命中或没 create_time 时只 walk msg/file（slow path 兜底）。
-    # 文件名匹配严格化：只接受精确匹配或 wechat 自动加副本的 "(N)" 后缀变体
-    # （round-8 high #1：之前用 `stem in f` 子串匹配会把"某某论文.pdf"当成 "论文.pdf"）。
+    # 文件名匹配严格化：只接受精确匹配或 wechat 自动加副本的 "(N)" 后缀变体，
+    # 不做 stem 子串匹配——避免 "某某论文.pdf" 被当成 "论文.pdf"。
     if not candidates:
         d = os.path.join(WECHAT_BASE_DIR, 'msg/file')
         stem, ext = os.path.splitext(title)
@@ -2124,9 +2118,9 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                 f"  说明：找到了同名文件但 size 都不匹配——可能从未真正下载完整 / 已被清理"
             )
 
-    # 威胁模型：本工具是用户主动通过 MCP 调用，path 只在本地对话显示，调用者
-    # 都是熟人。Codex round-6 强制"没 md5 fail-closed"对此场景过严——
-    # 回退到"有 md5 强校验，没 md5 heuristic + warning"的实用路线（round-5）。
+    # 路径绑定策略：有 md5 → cryptographic verify；没 md5 → heuristic +
+    # warning。本工具是用户主动通过 MCP 调用，path 只在本地对话显示，所以
+    # 没 md5 时不强制 fail-closed。
     cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
     md5_verified = False
     if expected_md5 and len(expected_md5) == 32:
@@ -2143,6 +2137,7 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                 continue
             if actual_md5 == expected_md5:
                 md5_match.append(c)
+                break  # 多候选共享同 md5 = 同一文件副本，第一个命中即停
         if not md5_match:
             info = (
                 f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
@@ -2158,11 +2153,10 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
 
     # 没 md5 时多 candidates 仍 fail-closed（避免 silent mtime pick）
     if len(candidates) > 1 and not md5_verified:
-        from datetime import datetime as _dt
         details = []
         for c in candidates:
             try:
-                mt = _dt.fromtimestamp(os.path.getmtime(c)).isoformat()
+                mt = datetime.fromtimestamp(os.path.getmtime(c)).isoformat()
             except OSError:
                 mt = '?'
             details.append(f"{c} (mtime={mt})")
@@ -2252,10 +2246,9 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
             return f"找不到 (local_id={local_id}, create_time={create_time}) 的消息（已扫描 {len(shards)} 个分片）"
         return f"找不到 local_id={local_id} 的消息（已扫描 {len(shards)} 个分片）"
     if len(matches) > 1:
-        from datetime import datetime as _dt
         details = []
         for tn, r in matches:
-            ts_str = _dt.fromtimestamp(r[1]).isoformat() if r[1] else '?'
+            ts_str = datetime.fromtimestamp(r[1]).isoformat() if r[1] else '?'
             details.append(f"table={tn[:12]}... create_time={r[1]} ({ts_str})")
         return (
             f"local_id={local_id} 在 {len(matches)} 个分片中都存在，无法唯一定位:\n  "
@@ -2319,17 +2312,11 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
     datasize = _parse_int(_collapse_text(item.findtext('datasize') or ''), 0)
     datafmt = _collapse_text(item.findtext('datafmt') or '')
     sourcename = _collapse_text(item.findtext('sourcename') or '')
-    # fullmd5 是文件内容唯一标识 —— 用于 binding 候选到本 record，避免误命中
-    # 同 chat 内别条 record 的同名同 size 文件（Codex round-5 high #2 真根治路径）。
+    # fullmd5 是文件内容唯一标识，用于把候选绑定到这条 record，避免误命中
+    # 同 chat 内别条 record 的同名同 size 文件。
     expected_md5 = _collapse_text(item.findtext('fullmd5') or '').lower()
 
-    type_label = {
-        '1': '文本', '2': '图片', '3': '名片', '4': '语音',
-        '5': '视频', '6': '链接', '7': '位置', '8': '文件',
-        '17': '聊天记录', '19': '小程序', '22': '视频号',
-        '23': '视频号直播', '29': '音乐', '36': '小程序/H5',
-        '37': '表情包',
-    }.get(datatype, f'datatype={datatype}')
+    type_label = _RECORD_DATATYPE_LABEL.get(datatype, f'datatype={datatype}')
 
     if datatype == '1':
         text_content = _collapse_text(item.findtext('datadesc') or '')
@@ -2341,9 +2328,9 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
 
     # 仅以下 datatype 在 wechat 缓存里有真本地 binary（图片/语音/视频/文件）；
     # 其他类型如链接/位置/名片/小程序/视频号/嵌套聊天记录等只是 metadata，
-    # 没有可下载的本地副本。**不在白名单里的 datatype 直接拒绝**，避免 sub='*'
-    # 通配命中无关 record 的同名文件。Codex round-3 medium #1。
-    subdir_map = {'8': 'F', '2': 'Img', '5': 'V', '4': 'A'}
+    # 没有可下载的本地副本。不在白名单里的 datatype 直接拒绝，避免 wildcard
+    # sub='*' 通配命中无关 record 的同名文件。
+    subdir_map = _RECORD_BINARY_SUBDIR
     if datatype not in subdir_map:
         return (
             f"该 dataitem 类型 [{type_label}] 没有本地 binary 文件，无需下载\n"
@@ -2365,7 +2352,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
         idx_str = str(item_index)
 
         # datatype=2 图片走 flat 文件命名 (Img/0_t / Img/0 / Img/0.{ext})，
-        # 不像文件类的 F/{idx}/{filename}。Codex round-7 medium #2 实测纠正。
+        # 不像文件类的 F/{idx}/{filename}。
         if datatype == '2':
             flat_patterns = [
                 f"{idx_str}_t",
@@ -2374,7 +2361,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
                 f"{idx_str}_*",
             ]
             for fp in flat_patterns:
-                for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, fp)):
+                for hit in glob.glob(os.path.join(attach_dir, '*/Rec/*', sub, fp)):
                     if datasize:
                         try:
                             if os.path.getsize(hit) != datasize:
@@ -2386,8 +2373,8 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
 
         # 文件 / 视频 / 语音类: F|V|A/{idx}/{filename}
         if datatype != '2' and datatitle:
-            escaped_title = glob_mod.escape(datatitle)
-            for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, escaped_title)):
+            escaped_title = glob.escape(datatitle)
+            for hit in glob.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, escaped_title)):
                 if datasize:
                     try:
                         if os.path.getsize(hit) != datasize:
@@ -2399,7 +2386,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
 
         # size only 兜底：仅在 datatitle 缺失且非 image（image 已上面处理）时启用
         if not candidates and not datatitle and datasize and datatype != '2':
-            for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, '*')):
+            for hit in glob.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, '*')):
                 try:
                     if os.path.getsize(hit) == datasize:
                         candidates.append(hit)
@@ -2436,6 +2423,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
                 continue
             if actual_md5 == expected_md5:
                 md5_match.append(c)
+                break  # 多候选共享同 md5 = 同一文件副本，第一个命中即停
         if not md5_match:
             info = (
                 f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
@@ -2451,11 +2439,10 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
 
     # 没 fullmd5 时多 candidates 仍 fail-closed
     if len(candidates) > 1 and not md5_verified:
-        from datetime import datetime as _dt
         details = []
         for c in candidates:
             try:
-                mt = _dt.fromtimestamp(os.path.getmtime(c)).isoformat()
+                mt = datetime.fromtimestamp(os.path.getmtime(c)).isoformat()
             except OSError:
                 mt = '?'
             details.append(f"{c} (mtime={mt})")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -615,10 +615,14 @@ def _parse_app_message_outer(content):
     """Parse outer appmsg XML，自动在 default 20K 上限拒绝时用 _RECORD_XML_PARSE_MAX_LEN
     重试。这是因为 type=19 合并转发卡片的 outer XML 可超 20K，所有解析 outer appmsg
     的 caller（get_chat_history 渲染 / decode_file_message / decode_record_item）都
-    必须共用此宽容路径，否则同一条大消息在不同 caller 上行为不一致。"""
+    必须共用此宽容路径，否则同一条大消息在不同 caller 上行为不一致。
+
+    Codex round-5 medium：只对**真的 type=19 合并卡片**放宽——用 substring 短路
+    避免每条非 type=19 的大 appmsg 都付出 500K parse 代价。"""
     root = _parse_xml_root(content)
     if root is None and content and len(content) <= _RECORD_XML_PARSE_MAX_LEN:
-        root = _parse_xml_root(content, max_len=_RECORD_XML_PARSE_MAX_LEN)
+        if '<type>19</type>' in content:
+            root = _parse_xml_root(content, max_len=_RECORD_XML_PARSE_MAX_LEN)
     return root
 
 
@@ -1980,6 +1984,8 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
     raw_title = _collapse_text(appmsg.findtext('title') or '')
     fileext = _collapse_text(appmsg.findtext('.//fileext') or '')
     totallen = _parse_int(_collapse_text(appmsg.findtext('.//totallen') or ''), 0)
+    # md5 字段在 type=6 外层（不是 appattach 子节点）—— 用于强校验候选文件归属
+    expected_md5 = _collapse_text(appmsg.findtext('md5') or '').lower()
 
     # 没有 appattach 节点 = 不是真正的文件消息（type=6 必带 appattach）
     if appmsg.find('appattach') is None:
@@ -2031,12 +2037,13 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                     if hit not in candidates:
                         candidates.append(hit)
 
-    # 退路：未命中或没 create_time 时全盘 walk（slow path，保留原始行为兜底）
+    # 退路：未命中或没 create_time 时只 walk msg/file（slow path 兜底）
+    # 不再扫 msg/attach —— 那是合并卡片/图片的缓存目录，外层文件不应该出现在那。
+    # Codex round-5 high #1：之前扫 msg/attach 会让另一条合并 record 里的同名同 size
+    # 文件被当作目标，silent 返回错副本。
     if not candidates:
-        for sub_dir in ('msg/file', 'msg/attach'):
-            d = os.path.join(WECHAT_BASE_DIR, sub_dir)
-            if not os.path.isdir(d):
-                continue
+        d = os.path.join(WECHAT_BASE_DIR, 'msg/file')
+        if os.path.isdir(d):
             for root_dir, _, files in os.walk(d):
                 for f in files:
                     if f.startswith('.'):
@@ -2070,10 +2077,37 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                 f"  说明：找到了同名文件但 size 都不匹配——可能从未真正下载完整 / 已被清理"
             )
 
-    # Fail closed：多 candidates 时报歧义而不是 silent mtime pick。
-    # decode_record_item 的同类问题在 round-2 high #2 已经 fail-closed，
-    # 这里跟它对齐——cross-tool consistency。
-    if len(candidates) > 1:
+    # md5 强校验提到 ambiguity 判断之前：
+    # 1. 如果 expected_md5 已知 → 用它过滤 candidates。同 md5 = 真同一文件副本（用户重发
+    #    或 wechat 加 (1) 后缀的复制），任选一个都对。剩 0 个则 md5 不匹配。
+    # 2. expected_md5 未知 → 退回 fail-closed：多 candidates 报歧义。
+    cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
+    md5_verified = False
+    if expected_md5 and len(expected_md5) == 32:
+        import hashlib as _hashlib
+        md5_match = []
+        for c in candidates:
+            if not _path_under_root(c, cache_root):
+                continue
+            try:
+                with open(c, 'rb') as _f:
+                    actual_md5 = _hashlib.md5(_f.read()).hexdigest().lower()
+                if actual_md5 == expected_md5:
+                    md5_match.append(c)
+            except OSError:
+                continue
+        if not md5_match:
+            return (
+                f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
+                f"  期望 md5: {expected_md5}\n"
+                f"  说明：找到 {len(candidates)} 个同名同 size 的本地文件但 md5 都不对。"
+                f"目标文件可能未在 wechat 客户端打开过，或已被清理。"
+            )
+        candidates = md5_match
+        md5_verified = True
+
+    # md5 不可用时（XML 无 md5 字段），多 candidates 仍 fail-closed
+    if len(candidates) > 1 and not md5_verified:
         from datetime import datetime as _dt
         details = []
         for c in candidates:
@@ -2083,26 +2117,28 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                 mt = '?'
             details.append(f"{c} (mtime={mt})")
         return (
-            f"在本地缓存找到 {len(candidates)} 个匹配的副本，无法唯一定位（同名同 size 多份）:\n  "
+            f"在本地缓存找到 {len(candidates)} 个匹配的副本，无法唯一定位（同名同 size 多份，且消息 XML 没含 md5 用于强校验）:\n  "
             + '\n  '.join(details)
             + f"\n请人工 inspect mtime / 上下文区分"
         )
 
     chosen = candidates[0]
-    # realpath 二次验证：拼接后仍在 wechat 缓存根下（防 symlink 跳出）
-    cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
     if not _path_under_root(chosen, cache_root):
         return f"匹配到的路径 {chosen!r} 不在 {cache_root} 下，拒绝返回（可能是 symlink 攻击）"
+
+    binding_note = (
+        "✅ md5 校验通过，路径与消息唯一绑定"
+        if md5_verified else
+        f"⚠️  消息 XML 没含 md5，路径只能基于 (filename+size) 启发式匹配。"
+        f"如果同 chat 缓存里另有同名同 size 的不相关文件，本工具可能返回错副本。请人工验证。"
+    )
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
         f"  大小: {os.path.getsize(chosen):,} bytes\n"
         f"  扩展名: {fileext or os.path.splitext(title)[1].lstrip('.') or '?'}\n"
         f"  期望大小: {totallen:,} bytes\n"
-        f"  ⚠️  此路径基于 (filename + size) 启发式匹配，没有从 wechat 元数据"
-        f"派生唯一证据证明它属于 local_id={local_id} 的消息。如果同 chat 缓存里"
-        f"另有同名同 size 的不相关文件，本工具可能返回错副本。请人工验证 mtime"
-        f"/路径上下文，或使用 Read 工具校对内容是否符合预期。"
+        f"  {binding_note}"
     )
 
 
@@ -2232,6 +2268,9 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
     datasize = _parse_int(_collapse_text(item.findtext('datasize') or ''), 0)
     datafmt = _collapse_text(item.findtext('datafmt') or '')
     sourcename = _collapse_text(item.findtext('sourcename') or '')
+    # fullmd5 是文件内容唯一标识 —— 用于 binding 候选到本 record，避免误命中
+    # 同 chat 内别条 record 的同名同 size 文件（Codex round-5 high #2 真根治路径）。
+    expected_md5 = _collapse_text(item.findtext('fullmd5') or '').lower()
 
     type_label = {
         '1': '文本', '2': '图片', '3': '名片', '4': '语音',
@@ -2333,6 +2372,31 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
     cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
     if not _path_under_root(chosen, cache_root):
         return f"匹配到的路径 {chosen!r} 不在 {cache_root} 下，拒绝返回（可能是 symlink 攻击）"
+
+    # md5 强校验：dataitem XML 含 fullmd5 时，必须本地文件 md5 完全匹配，
+    # 否则即使同名同 size 也是另一条 record 的同名文件 → fail closed
+    md5_verified = False
+    if expected_md5 and len(expected_md5) == 32:
+        import hashlib as _hashlib
+        try:
+            with open(chosen, 'rb') as _f:
+                actual_md5 = _hashlib.md5(_f.read()).hexdigest().lower()
+            if actual_md5 != expected_md5:
+                return (
+                    f"⚠️ 候选文件 md5 不匹配，拒绝返回错文件:\n"
+                    f"  路径: {chosen}\n"
+                    f"  期望 md5: {expected_md5}\n"
+                    f"  实际 md5: {actual_md5}\n"
+                    f"  说明：该路径上同位置同名同 size 的文件不属于 local_id={local_id} 的这条 record。"
+                    f"目标文件可能未在 wechat 客户端点开过，请去 wechat 点击下载第 {item_index + 1} 项。"
+                )
+            md5_verified = True
+        except OSError as e:
+            return f"读取候选文件 md5 失败: {e}"
+
+    binding_note = "✅ md5 校验通过，路径与 dataitem 唯一绑定" if md5_verified else \
+        f"⚠️  此 dataitem 的 XML 没含 fullmd5，路径只能基于 (item_index+filename+size) 启发式匹配。" \
+        f"如果同 chat 内多条合并卡片碰巧含同位置同名同 size 的文件，本工具可能返回别条 record 的副本。"
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
@@ -2340,10 +2404,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
         f"  期望大小: {datasize:,} bytes\n"
         f"  发送者: {sourcename}\n"
         f"  类型: [{type_label}] {datatitle or '(无标题)'}\n"
-        f"  ⚠️  此路径基于 (item_index + filename + size) 启发式匹配，无法从"
-        f"wechat 元数据派生唯一证据证明它属于 local_id={local_id} 的这条 record。"
-        f"如果同 chat 内多条合并卡片碰巧含同位置同名同 size 的文件，本工具可能"
-        f"返回别条 record 的副本。请用 mtime 或人工 inspect 校对。"
+        f"  {binding_note}"
     )
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1875,9 +1875,9 @@ def decode_file_message(chat_name: str, local_id: int) -> str:
     if not xml_text:
         return "消息 content 为空或无法解码"
 
-    # 剥离群聊 sender 前缀 "wxid_xxx:\n<xml...>"
-    if '<appmsg' in xml_text and ':\n' in xml_text and not xml_text.lstrip().startswith('<'):
-        xml_text = xml_text.split(':\n', 1)[1]
+    # 复用项目内现有 helper 剥离群聊 sender 前缀，避免自己写启发式
+    is_group = username.endswith('@chatroom')
+    _, xml_text = _parse_message_content(xml_text, local_type, is_group)
 
     root = _parse_xml_root(xml_text)
     if root is None:
@@ -2043,8 +2043,9 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
     if not xml_text:
         return "消息 content 为空或无法解码"
 
-    if '<appmsg' in xml_text and ':\n' in xml_text and not xml_text.lstrip().startswith('<'):
-        xml_text = xml_text.split(':\n', 1)[1]
+    # 复用项目内现有 helper 剥离群聊 sender 前缀，避免自己写启发式
+    is_group = username.endswith('@chatroom')
+    _, xml_text = _parse_message_content(xml_text, local_type, is_group)
 
     root = _parse_xml_root(xml_text)
     if root is None:

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -555,25 +555,15 @@ def _resolve_quote_sender_label(ref_user, ref_display_name, is_group, chat_usern
     return ''
 
 
-def _parse_xml_root(content):
-    if not content or len(content) > _XML_PARSE_MAX_LEN or _XML_UNSAFE_RE.search(content):
-        return None
-
-    try:
-        return ET.fromstring(content)
-    except ET.ParseError:
-        return None
-
-
-# 合并转发的 recorditem 内嵌 XML 在 dataitem 数量多时显著超过 20K，
-# 实测含 99 条 dataitem 的卡片可达 ~418KB，用更宽的上限专门解析。
+# 合并转发消息（含 recorditem 内嵌 XML）在 dataitem 数量多时显著超过默认 20K 上限，
+# 实测真实 outer XML 可达 ~500KB。caller 可通过 max_len 参数为 type=19 类大消息放宽限制。
 _RECORD_XML_PARSE_MAX_LEN = 500_000
 
 
-def _parse_record_xml(content):
-    """专用于 recorditem 内嵌 XML 解析，允许更大 payload。"""
-    if not content or len(content) > _RECORD_XML_PARSE_MAX_LEN or _XML_UNSAFE_RE.search(content):
+def _parse_xml_root(content, max_len=_XML_PARSE_MAX_LEN):
+    if not content or len(content) > max_len or _XML_UNSAFE_RE.search(content):
         return None
+
     try:
         return ET.fromstring(content)
     except ET.ParseError:
@@ -593,6 +583,11 @@ def _format_app_message_text(content, local_type, is_group, chat_username, chat_
 
     _, sub_type = _split_msg_type(local_type)
     root = _parse_xml_root(content)
+    if root is None and len(content) <= _RECORD_XML_PARSE_MAX_LEN:
+        # type=19 合并转发卡片 outer XML 可超过默认 20K，必要时用更宽上限重试，
+        # 否则展开链 _format_record_message_text → _parse_xml_root(record_node.text)
+        # 永远到不了，大合并消息会静默退化为 [链接/文件]。
+        root = _parse_xml_root(content, max_len=_RECORD_XML_PARSE_MAX_LEN)
     if root is None:
         return None
 
@@ -703,7 +698,7 @@ def _format_record_message_text(appmsg, title):
     if record_node is None or not record_node.text:
         return f"[聊天记录] {fallback_title}（待加载）"
 
-    inner = _parse_record_xml(record_node.text)
+    inner = _parse_xml_root(record_node.text, max_len=_RECORD_XML_PARSE_MAX_LEN)
     if inner is None:
         return f"[聊天记录] {fallback_title}"
 
@@ -721,7 +716,7 @@ def _format_record_message_text(appmsg, title):
     header += f"，共 {len(items)} 条"
 
     lines = [header + ":"]
-    for item in items[:_RECORD_MAX_ITEMS]:
+    for idx, item in enumerate(items[:_RECORD_MAX_ITEMS]):
         sender = _collapse_text(item.findtext('sourcename') or '')
         when = _collapse_text(item.findtext('sourcetime') or '')
         content = _format_record_dataitem(item)
@@ -729,9 +724,10 @@ def _format_record_message_text(appmsg, title):
         if len(content) > _RECORD_MAX_LINE_LEN:
             content = content[:_RECORD_MAX_LINE_LEN] + '…'
 
-        prefix_parts = [p for p in (when, sender) if p]
+        # 0-based index 让用户能用 decode_record_item(chat, local_id, item_index) 引用
+        prefix_parts = [f"[{idx}]"] + [p for p in (when, sender) if p]
         prefix = ' '.join(prefix_parts)
-        lines.append(f"  {prefix}: {content}" if prefix else f"  {content}")
+        lines.append(f"  {prefix}: {content}")
 
     if len(items) > _RECORD_MAX_ITEMS:
         lines.append(f"  …（还有 {len(items) - _RECORD_MAX_ITEMS} 条未显示）")
@@ -768,20 +764,37 @@ def _format_voip_message_text(content):
     return f"[通话] {status_map.get(raw_text, raw_text)}"
 
 
-def _format_message_text(local_id, local_type, content, is_group, chat_username, chat_display_name, names):
+def _format_message_text(local_id, local_type, content, is_group, chat_username, chat_display_name, names, create_time=0):
     sender_from_content, text = _parse_message_content(content, local_type, is_group)
     base_type, _ = _split_msg_type(local_type)
 
+    # 同一 chat 的消息可能跨 message_N.db 分片，导致 local_id 跨分片冲突。
+    # 把 create_time 一起注入到输出，让 decode_file_message / decode_record_item
+    # 能用 (local_id, create_time) 唯一定位 row。
+    def _id_suffix():
+        return f"(local_id={local_id}, ts={create_time})" if create_time else f"(local_id={local_id})"
+
     if base_type == 3:
-        text = f"[图片] (local_id={local_id})"
+        text = f"[图片] {_id_suffix()}"
     elif base_type == 47:
         text = "[表情]"
     elif base_type == 50:
         text = _format_voip_message_text(text) or "[通话]"
     elif base_type == 49:
-        text = _format_app_message_text(
+        formatted = _format_app_message_text(
             text, local_type, is_group, chat_username, chat_display_name, names
         ) or "[链接/文件]"
+        if formatted.startswith('[文件]'):
+            formatted = f"{formatted} {_id_suffix()}"
+        elif formatted.startswith('[聊天记录]'):
+            # 多行：把 ID 后缀放在 header 末尾，":" 之前
+            if '\n' in formatted:
+                first_line, rest = formatted.split('\n', 1)
+                first_line_no_colon = first_line.rstrip(':').rstrip()
+                formatted = f"{first_line_no_colon} {_id_suffix()}:\n{rest}"
+            else:
+                formatted = f"{formatted} {_id_suffix()}"
+        text = formatted
     elif base_type != 1:
         type_label = format_msg_type(local_type)
         text = f"[{type_label}] {text}" if text else f"[{type_label}]"
@@ -1042,7 +1055,8 @@ def _build_search_entry(row, ctx, names, id_to_username):
         return None
 
     sender, text = _format_message_text(
-        local_id, local_type, content, ctx['is_group'], ctx['username'], ctx['display_name'], names
+        local_id, local_type, content, ctx['is_group'], ctx['username'], ctx['display_name'], names,
+        create_time=create_time,
     )
     if text and len(text) > 300:
         text = text[:300] + '...'
@@ -1072,7 +1086,8 @@ def _build_history_line(row, ctx, names, id_to_username):
         content = '(无法解压)'
 
     sender, text = _format_message_text(
-        local_id, local_type, content, ctx['is_group'], ctx['username'], ctx['display_name'], names
+        local_id, local_type, content, ctx['is_group'], ctx['username'], ctx['display_name'], names,
+        create_time=create_time,
     )
 
     sender_label = _resolve_sender_label(
@@ -1817,58 +1832,83 @@ def decode_image(chat_name: str, local_id: int) -> str:
 
 
 @mcp.tool()
-def decode_file_message(chat_name: str, local_id: int) -> str:
+def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> str:
     """获取微信聊天中外层文件消息（PDF/docx/xlsx 等）的本地副本路径。
 
     微信会把对方发来的文件下载到 ~/Library/.../msg/file/{YYYY-MM}/原文件名.{ext}
     （macOS）。本工具从消息记录解析出文件名/大小，在本地缓存中精确定位，
     然后返回原始路径，可直接交给 Read/PDF 工具读取。
 
-    使用流程：先用 get_chat_history 找到 [文件] xxx.pdf 类消息的 local_id，
-    再用本工具拿到本地路径。
+    使用流程：先用 get_chat_history 找到 [文件] xxx.pdf (local_id=N, ts=T)，
+    把 N 和 T 一起传给本工具。create_time(ts) 用于跨分片场景下唯一定位。
 
     Args:
         chat_name: 聊天对象的名字、备注名或wxid
         local_id: 文件消息的 local_id（从 get_chat_history 获取）
+        create_time: 消息的 unix 时间戳，从 get_chat_history 输出 ts=N 部分获取。
+            用于在 local_id 跨分片冲突时唯一定位；传 0 时若多个分片含同 local_id 会报歧义错误
     """
     try:
         local_id = int(local_id)
+        create_time = int(create_time)
     except (TypeError, ValueError):
-        return "错误: local_id 必须是整数"
+        return "错误: local_id 和 create_time 必须是整数"
 
     username = resolve_username(chat_name)
     if not username:
         return f"找不到聊天对象: {chat_name}"
 
-    # 同一 chat 的消息可能分散在多个 message_N.db 分片中，遍历所有分片查 local_id
+    # 同一 chat 的消息可能分散在多个 message_N.db 分片中。扫所有分片收集 row，
+    # 多于一条就报歧义错误（避免 silent decoding wrong message）。
     shards = _find_msg_tables_for_user(username)
     if not shards:
         return f"找不到 {chat_name} 的消息表"
 
-    row = None
-    table_name = None
+    # 扫所有分片收集 row。如果调用者传了 create_time，用 (local_id, create_time)
+    # 精确匹配；否则只按 local_id 收集，多匹配时报歧义并提示加 create_time。
+    matches = []
     for shard in shards:
         if not _is_safe_msg_table_name(shard['table_name']):
             continue
         with closing(sqlite3.connect(shard['db_path'])) as conn:
-            candidate_row = conn.execute(
-                f"SELECT local_type, create_time, message_content, WCDB_CT_message_content "
-                f"FROM [{shard['table_name']}] WHERE local_id=?",
-                (local_id,)
-            ).fetchone()
+            if create_time:
+                candidate_row = conn.execute(
+                    f"SELECT local_type, create_time, message_content, WCDB_CT_message_content "
+                    f"FROM [{shard['table_name']}] WHERE local_id=? AND create_time=?",
+                    (local_id, create_time)
+                ).fetchone()
+            else:
+                candidate_row = conn.execute(
+                    f"SELECT local_type, create_time, message_content, WCDB_CT_message_content "
+                    f"FROM [{shard['table_name']}] WHERE local_id=?",
+                    (local_id,)
+                ).fetchone()
         if candidate_row:
-            row = candidate_row
-            table_name = shard['table_name']
-            break
-    if not row:
+            matches.append((shard['db_path'], candidate_row))
+    if not matches:
+        if create_time:
+            return f"找不到 (local_id={local_id}, create_time={create_time}) 的消息（已扫描 {len(shards)} 个分片）"
         return f"找不到 local_id={local_id} 的消息（已扫描 {len(shards)} 个分片）"
+    if len(matches) > 1:
+        from datetime import datetime as _dt
+        details = []
+        for db_p, r in matches:
+            ct = r[1]
+            ts_str = _dt.fromtimestamp(ct).isoformat() if ct else '?'
+            details.append(f"{os.path.basename(db_p)} create_time={ct} ({ts_str})")
+        return (
+            f"local_id={local_id} 在 {len(matches)} 个分片中都存在，无法唯一定位:\n  "
+            + '\n  '.join(details)
+            + f"\n请加 create_time 参数：decode_file_message(chat_name, local_id={local_id}, create_time=N)"
+        )
 
+    _, row = matches[0]
     local_type, create_time, content, ct_compress = row
     base_type, _ = _split_msg_type(local_type)
     if base_type != 49:
         return (
             f"不是文件消息（local_type={local_type}，base_type={base_type}），"
-            f"文件消息应为 base_type=49 且 sub_type=6"
+            f"文件消息应为 base_type=49 且 appmsg type=6"
         )
 
     xml_text = _decompress_content(content, ct_compress)
@@ -1887,9 +1927,23 @@ def decode_file_message(chat_name: str, local_id: int) -> str:
     if appmsg is None:
         return "消息中没有 appmsg 段（可能不是文件类型）"
 
+    # 必须是 appmsg type=6 (文件)，否则可能是链接/小程序/合并转发等带 title 的卡片，
+    # 按 title/size 全盘搜会误命中无关本地文件并伪装成"找到了"。
+    app_type_in_msg = _parse_int(_collapse_text(appmsg.findtext('type') or ''), 0)
+    if app_type_in_msg != 6:
+        return (
+            f"不是文件消息（appmsg type={app_type_in_msg}）。"
+            f"文件消息要求 appmsg type=6；type=19 请用 decode_record_item，"
+            f"type=5/33/36/44 等是链接/小程序，没有可下载的本地文件"
+        )
+
     title = _collapse_text(appmsg.findtext('title') or '')
     fileext = _collapse_text(appmsg.findtext('.//fileext') or '')
     totallen = _parse_int(_collapse_text(appmsg.findtext('.//totallen') or ''), 0)
+
+    # 没有 appattach 节点 = 不是真正的文件消息（type=6 必带 appattach）
+    if appmsg.find('appattach') is None:
+        return "消息没有 appattach 节点（可能 schema 异常或不是真文件消息）"
 
     if not title:
         return "消息中没有文件名 (title)"
@@ -1981,13 +2035,13 @@ def decode_file_message(chat_name: str, local_id: int) -> str:
 
 
 @mcp.tool()
-def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
+def decode_record_item(chat_name: str, local_id: int, item_index: int, create_time: int = 0) -> str:
     """获取合并转发聊天记录中某个内嵌文件/图片的本地副本路径。
 
     使用流程：
-    1. 先用 get_chat_history 找到 [聊天记录] xxx 卡片，记下其 local_id 以及要的
-       dataitem 在 datalist 里的位置（0-based，第一条 = 0）
-    2. 用本工具拿本地路径
+    1. 先用 get_chat_history 找到 [聊天记录] xxx (local_id=N, ts=T) 卡片，记下 N 和 T，
+       以及展开行里 [item_index] 前缀（0-based）
+    2. 用本工具拿本地路径，create_time 传 history 里的 ts 部分
     3. 如果未下载，工具会精确告诉你去 wechat 客户端点击合并卡片里的第几项触发下载
 
     注意：合并转发里的内嵌文件只有在用户**点击查看**后 wechat 才会下载到本地。
@@ -1996,42 +2050,62 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
     Args:
         chat_name: 聊天对象的名字、备注名或wxid
         local_id: 合并转发消息（带"[聊天记录]"标记）的 local_id
-        item_index: dataitem 在 datalist 里的 0-based 索引
+        item_index: dataitem 在 datalist 里的 0-based 索引（history 输出里的 [N] 前缀）
+        create_time: 消息的 unix 时间戳；用于跨分片唯一定位，传 0 时多匹配会报歧义
     """
     try:
         local_id = int(local_id)
         item_index = int(item_index)
+        create_time = int(create_time)
     except (TypeError, ValueError):
-        return "错误: local_id 和 item_index 必须是整数"
+        return "错误: local_id / item_index / create_time 必须是整数"
 
     username = resolve_username(chat_name)
     if not username:
         return f"找不到聊天对象: {chat_name}"
 
-    # 同一 chat 的消息可能分散在多个 message_N.db 分片中，遍历所有分片查 local_id
+    # 多分片扫描 + ambiguity 检测（避免 silent decoding wrong message，参考 decode_file_message）
     shards = _find_msg_tables_for_user(username)
     if not shards:
         return f"找不到 {chat_name} 的消息表"
 
-    row = None
-    table_name = None
+    matches = []
     for shard in shards:
         if not _is_safe_msg_table_name(shard['table_name']):
             continue
         with closing(sqlite3.connect(shard['db_path'])) as conn:
-            candidate_row = conn.execute(
-                f"SELECT local_type, message_content, WCDB_CT_message_content "
-                f"FROM [{shard['table_name']}] WHERE local_id=?",
-                (local_id,)
-            ).fetchone()
+            if create_time:
+                candidate_row = conn.execute(
+                    f"SELECT local_type, create_time, message_content, WCDB_CT_message_content "
+                    f"FROM [{shard['table_name']}] WHERE local_id=? AND create_time=?",
+                    (local_id, create_time)
+                ).fetchone()
+            else:
+                candidate_row = conn.execute(
+                    f"SELECT local_type, create_time, message_content, WCDB_CT_message_content "
+                    f"FROM [{shard['table_name']}] WHERE local_id=?",
+                    (local_id,)
+                ).fetchone()
         if candidate_row:
-            row = candidate_row
-            table_name = shard['table_name']
-            break
-    if not row:
+            matches.append((shard['table_name'], candidate_row))
+    if not matches:
+        if create_time:
+            return f"找不到 (local_id={local_id}, create_time={create_time}) 的消息（已扫描 {len(shards)} 个分片）"
         return f"找不到 local_id={local_id} 的消息（已扫描 {len(shards)} 个分片）"
+    if len(matches) > 1:
+        from datetime import datetime as _dt
+        details = []
+        for tn, r in matches:
+            ts_str = _dt.fromtimestamp(r[1]).isoformat() if r[1] else '?'
+            details.append(f"table={tn[:12]}... create_time={r[1]} ({ts_str})")
+        return (
+            f"local_id={local_id} 在 {len(matches)} 个分片中都存在，无法唯一定位:\n  "
+            + '\n  '.join(details)
+            + f"\n请加 create_time 参数：decode_record_item(chat_name, local_id={local_id}, item_index={item_index}, create_time=N)"
+        )
 
-    local_type, content, ct_compress = row
+    table_name, row = matches[0]
+    local_type, _create_time, content, ct_compress = row
     base_type, _ = _split_msg_type(local_type)
     if base_type != 49:
         return (
@@ -2065,7 +2139,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
     if record_node is None or not record_node.text:
         return "消息中没有 recorditem（datalist 还未加载，请在 wechat 中点开此卡片让客户端拉取）"
 
-    inner = _parse_record_xml(record_node.text)
+    inner = _parse_xml_root(record_node.text, max_len=_RECORD_XML_PARSE_MAX_LEN)
     if inner is None:
         return "无法解析 recorditem 内嵌 XML"
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2021,22 +2021,40 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
             f"  可能原因：从未在 PC/Mac 微信打开过 / 已被清理"
         )
 
-    # 优先取 size 完全匹配的；并按 mtime 最近排序
-    size_match = [c for c in candidates if totallen and os.path.getsize(c) == totallen]
-    if size_match:
-        candidates = size_match
-    candidates.sort(key=lambda p: -os.path.getmtime(p))
-    chosen = candidates[0]
+    # 严格 size 过滤（如果 totallen 已知，不匹配的全淘汰）
+    if totallen:
+        candidates = [c for c in candidates if os.path.getsize(c) == totallen]
+        if not candidates:
+            return (
+                f"在本地缓存中找不到 {title} (期望 size={totallen:,})\n"
+                f"  说明：找到了同名文件但 size 都不匹配——可能从未真正下载完整 / 已被清理"
+            )
 
-    extra = ""
+    # Fail closed：多 candidates 时报歧义而不是 silent mtime pick。
+    # decode_record_item 的同类问题在 round-2 high #2 已经 fail-closed，
+    # 这里跟它对齐——cross-tool consistency。
     if len(candidates) > 1:
-        extra = f"\n  其他候选: {len(candidates) - 1} 个"
+        from datetime import datetime as _dt
+        details = []
+        for c in candidates:
+            try:
+                mt = _dt.fromtimestamp(os.path.getmtime(c)).isoformat()
+            except OSError:
+                mt = '?'
+            details.append(f"{c} (mtime={mt})")
+        return (
+            f"在本地缓存找到 {len(candidates)} 个匹配的副本，无法唯一定位（同名同 size 多份）:\n  "
+            + '\n  '.join(details)
+            + f"\n请人工 inspect mtime / 上下文区分"
+        )
+
+    chosen = candidates[0]
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
         f"  大小: {os.path.getsize(chosen):,} bytes\n"
         f"  扩展名: {fileext or os.path.splitext(title)[1].lstrip('.') or '?'}\n"
-        f"  期望大小: {totallen:,} bytes" + extra
+        f"  期望大小: {totallen:,} bytes"
     )
 
 
@@ -2179,12 +2197,24 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
             f"  内容: {text_content}"
         )
 
+    # 仅以下 datatype 在 wechat 缓存里有真本地 binary（图片/语音/视频/文件）；
+    # 其他类型如链接/位置/名片/小程序/视频号/嵌套聊天记录等只是 metadata，
+    # 没有可下载的本地副本。**不在白名单里的 datatype 直接拒绝**，避免 sub='*'
+    # 通配命中无关 record 的同名文件。Codex round-3 medium #1。
+    subdir_map = {'8': 'F', '2': 'Img', '5': 'V', '4': 'A'}
+    if datatype not in subdir_map:
+        return (
+            f"该 dataitem 类型 [{type_label}] 没有本地 binary 文件，无需下载\n"
+            f"  发送者: {sourcename}\n"
+            f"  标题: {datatitle or '(无)'}\n"
+            f"  说明：仅 datatype=2/4/5/8（图片/语音/视频/文件）有可下载内容；"
+            f"链接/位置/名片/小程序/视频号/嵌套聊天记录等是 metadata-only。"
+            f"\n如果你需要这条 dataitem 的 metadata 详情，看 get_chat_history 输出里"
+            f"已展开的 [{item_index}] 行内容即可。"
+        )
+
     table_hash = table_name.replace('Msg_', '', 1)
     attach_dir = os.path.join(WECHAT_BASE_DIR, 'msg/attach', table_hash)
-
-    # 文件类（datatype=8）落 F/{idx}/，图片类落 Img/{idx}/，视频类落 V/{idx}/
-    # 提到 if-block 之外，否则下方 not-found 分支引用时会 UnboundLocalError
-    subdir_map = {'8': 'F', '2': 'Img', '5': 'V', '4': 'A'}
 
     candidates = []
     if os.path.isdir(attach_dir):

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -594,6 +594,38 @@ def _path_under_root(path, root):
     return real_path == real_root or real_path.startswith(real_root + os.sep)
 
 
+# 大附件 md5 校验时的安全上限：超过此 size 直接拒绝校验（避免 MCP 进程
+# 在 100MB+ 视频/附件上一次性 read() 整文件爆内存或长时间阻塞）。
+_MD5_VERIFY_MAX_SIZE = 500 * 1024 * 1024  # 500 MB
+_MD5_CHUNK_SIZE = 64 * 1024  # 64 KB
+
+
+def _md5_file_chunked(path, max_size=_MD5_VERIFY_MAX_SIZE):
+    """流式分块计算文件 md5，避免大文件一次读完爆内存。
+
+    超过 max_size 直接拒绝（DoS 防御 + 大附件 md5 校验现实意义不大）。
+    返回 (md5_hex, error)；成功时 error 为 None。
+    """
+    import hashlib as _hashlib
+    try:
+        size = os.path.getsize(path)
+    except OSError as e:
+        return None, f"无法读取文件 size: {e}"
+    if size > max_size:
+        return None, f"文件 size {size:,} 超过 md5 校验上限 {max_size:,}（防 DoS）"
+    h = _hashlib.md5()
+    try:
+        with open(path, 'rb') as f:
+            while True:
+                chunk = f.read(_MD5_CHUNK_SIZE)
+                if not chunk:
+                    break
+                h.update(chunk)
+    except OSError as e:
+        return None, f"读取文件失败: {e}"
+    return h.hexdigest().lower(), None
+
+
 def _parse_xml_root(content, max_len=_XML_PARSE_MAX_LEN):
     if not content or len(content) > max_len or _XML_UNSAFE_RE.search(content):
         return None
@@ -2077,68 +2109,60 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
                 f"  说明：找到了同名文件但 size 都不匹配——可能从未真正下载完整 / 已被清理"
             )
 
-    # md5 强校验提到 ambiguity 判断之前：
-    # 1. 如果 expected_md5 已知 → 用它过滤 candidates。同 md5 = 真同一文件副本（用户重发
-    #    或 wechat 加 (1) 后缀的复制），任选一个都对。剩 0 个则 md5 不匹配。
-    # 2. expected_md5 未知 → 退回 fail-closed：多 candidates 报歧义。
+    # 没有 md5 = 没法 cryptographic 证明候选属于该消息 → fail closed。
+    # 之前的 "heuristic + warning" 不够：candidates==1 时 warning 形同虚设，
+    # downstream 会把无关同名同 size 文件当成目标读。Codex round-6 high #1。
     cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
-    md5_verified = False
-    if expected_md5 and len(expected_md5) == 32:
-        import hashlib as _hashlib
-        md5_match = []
-        for c in candidates:
-            if not _path_under_root(c, cache_root):
-                continue
-            try:
-                with open(c, 'rb') as _f:
-                    actual_md5 = _hashlib.md5(_f.read()).hexdigest().lower()
-                if actual_md5 == expected_md5:
-                    md5_match.append(c)
-            except OSError:
-                continue
-        if not md5_match:
-            return (
-                f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
-                f"  期望 md5: {expected_md5}\n"
-                f"  说明：找到 {len(candidates)} 个同名同 size 的本地文件但 md5 都不对。"
-                f"目标文件可能未在 wechat 客户端打开过，或已被清理。"
-            )
-        candidates = md5_match
-        md5_verified = True
-
-    # md5 不可用时（XML 无 md5 字段），多 candidates 仍 fail-closed
-    if len(candidates) > 1 and not md5_verified:
+    if not (expected_md5 and len(expected_md5) == 32):
         from datetime import datetime as _dt
         details = []
-        for c in candidates:
+        for c in candidates[:5]:
             try:
                 mt = _dt.fromtimestamp(os.path.getmtime(c)).isoformat()
             except OSError:
                 mt = '?'
             details.append(f"{c} (mtime={mt})")
+        more = "" if len(candidates) <= 5 else f"\n  …还有 {len(candidates) - 5} 个候选"
         return (
-            f"在本地缓存找到 {len(candidates)} 个匹配的副本，无法唯一定位（同名同 size 多份，且消息 XML 没含 md5 用于强校验）:\n  "
+            f"消息 XML 没含 md5 字段，本工具拒绝基于 (filename+size) 启发式返回路径"
+            f"（避免 silent 命中无关消息的同名缓存）:\n  "
             + '\n  '.join(details)
-            + f"\n请人工 inspect mtime / 上下文区分"
+            + more
+            + f"\n如确实需要这个文件，请人工 inspect 候选并直接 Read 你认可的 path"
         )
 
-    chosen = candidates[0]
-    if not _path_under_root(chosen, cache_root):
-        return f"匹配到的路径 {chosen!r} 不在 {cache_root} 下，拒绝返回（可能是 symlink 攻击）"
+    # 用 expected_md5 过滤 candidates；同 md5 = 真同一文件副本。
+    md5_match = []
+    md5_errors = []
+    for c in candidates:
+        if not _path_under_root(c, cache_root):
+            md5_errors.append(f"{c}: 不在 {cache_root} 下，跳过")
+            continue
+        actual_md5, err = _md5_file_chunked(c)
+        if err:
+            md5_errors.append(f"{c}: {err}")
+            continue
+        if actual_md5 == expected_md5:
+            md5_match.append(c)
+    if not md5_match:
+        info = (
+            f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
+            f"  期望 md5: {expected_md5}\n"
+            f"  说明：找到 {len(candidates)} 个同名同 size 的本地文件但 md5 都不对。"
+            f"目标文件可能未在 wechat 客户端打开过，或已被清理。"
+        )
+        if md5_errors:
+            info += "\n  校验异常：\n    " + "\n    ".join(md5_errors)
+        return info
 
-    binding_note = (
-        "✅ md5 校验通过，路径与消息唯一绑定"
-        if md5_verified else
-        f"⚠️  消息 XML 没含 md5，路径只能基于 (filename+size) 启发式匹配。"
-        f"如果同 chat 缓存里另有同名同 size 的不相关文件，本工具可能返回错副本。请人工验证。"
-    )
+    chosen = md5_match[0]
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
         f"  大小: {os.path.getsize(chosen):,} bytes\n"
         f"  扩展名: {fileext or os.path.splitext(title)[1].lstrip('.') or '?'}\n"
         f"  期望大小: {totallen:,} bytes\n"
-        f"  {binding_note}"
+        f"  ✅ md5 校验通过，路径与消息唯一绑定"
     )
 
 
@@ -2367,36 +2391,53 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
             + f"\n请通过其他途径区分（人工 inspect mtime 或匹配上下文）"
         )
 
-    chosen = candidates[0]
-    # realpath 二次验证：拼接后仍在 wechat 缓存根下（防 symlink 跳出）
     cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
-    if not _path_under_root(chosen, cache_root):
-        return f"匹配到的路径 {chosen!r} 不在 {cache_root} 下，拒绝返回（可能是 symlink 攻击）"
+    # 没 fullmd5 = 没法 cryptographic 证明候选属于该 record → fail closed。
+    # Codex round-6 high #2: candidates==1 时 ⚠️ warning 不能阻止下游使用错路径。
+    if not (expected_md5 and len(expected_md5) == 32):
+        from datetime import datetime as _dt
+        details = []
+        for c in candidates[:5]:
+            try:
+                mt = _dt.fromtimestamp(os.path.getmtime(c)).isoformat()
+            except OSError:
+                mt = '?'
+            details.append(f"{c} (mtime={mt})")
+        more = "" if len(candidates) <= 5 else f"\n  …还有 {len(candidates) - 5} 个候选"
+        return (
+            f"该 dataitem XML 没含 fullmd5 字段，本工具拒绝基于"
+            f" (item_index+filename+size) 启发式返回路径\n"
+            f"（避免 silent 返回同 chat 内别条 record 的同名同 size 文件）:\n  "
+            + '\n  '.join(details)
+            + more
+            + f"\n如确实需要，请人工 inspect 候选并直接 Read 你认可的 path"
+        )
 
-    # md5 强校验：dataitem XML 含 fullmd5 时，必须本地文件 md5 完全匹配，
-    # 否则即使同名同 size 也是另一条 record 的同名文件 → fail closed
-    md5_verified = False
-    if expected_md5 and len(expected_md5) == 32:
-        import hashlib as _hashlib
-        try:
-            with open(chosen, 'rb') as _f:
-                actual_md5 = _hashlib.md5(_f.read()).hexdigest().lower()
-            if actual_md5 != expected_md5:
-                return (
-                    f"⚠️ 候选文件 md5 不匹配，拒绝返回错文件:\n"
-                    f"  路径: {chosen}\n"
-                    f"  期望 md5: {expected_md5}\n"
-                    f"  实际 md5: {actual_md5}\n"
-                    f"  说明：该路径上同位置同名同 size 的文件不属于 local_id={local_id} 的这条 record。"
-                    f"目标文件可能未在 wechat 客户端点开过，请去 wechat 点击下载第 {item_index + 1} 项。"
-                )
-            md5_verified = True
-        except OSError as e:
-            return f"读取候选文件 md5 失败: {e}"
+    # md5 过滤候选
+    md5_match = []
+    md5_errors = []
+    for c in candidates:
+        if not _path_under_root(c, cache_root):
+            md5_errors.append(f"{c}: 不在 {cache_root} 下，跳过")
+            continue
+        actual_md5, err = _md5_file_chunked(c)
+        if err:
+            md5_errors.append(f"{c}: {err}")
+            continue
+        if actual_md5 == expected_md5:
+            md5_match.append(c)
+    if not md5_match:
+        info = (
+            f"⚠️ 候选文件 md5 都不匹配，拒绝返回错文件:\n"
+            f"  期望 md5: {expected_md5}\n"
+            f"  说明：候选 {len(candidates)} 个，md5 都不对。"
+            f"目标 dataitem 可能未在 wechat 客户端点开过，请点击第 {item_index + 1} 项触发下载。"
+        )
+        if md5_errors:
+            info += "\n  校验异常：\n    " + "\n    ".join(md5_errors)
+        return info
 
-    binding_note = "✅ md5 校验通过，路径与 dataitem 唯一绑定" if md5_verified else \
-        f"⚠️  此 dataitem 的 XML 没含 fullmd5，路径只能基于 (item_index+filename+size) 启发式匹配。" \
-        f"如果同 chat 内多条合并卡片碰巧含同位置同名同 size 的文件，本工具可能返回别条 record 的副本。"
+    chosen = md5_match[0]
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
@@ -2404,7 +2445,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
         f"  期望大小: {datasize:,} bytes\n"
         f"  发送者: {sourcename}\n"
         f"  类型: [{type_label}] {datatitle or '(无标题)'}\n"
-        f"  {binding_note}"
+        f"  ✅ md5 校验通过，路径与 dataitem 唯一绑定"
     )
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -2032,11 +2032,13 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
     table_hash = table_name.replace('Msg_', '', 1)
     attach_dir = os.path.join(WECHAT_BASE_DIR, 'msg/attach', table_hash)
 
+    # 文件类（datatype=8）落 F/{idx}/，图片类落 Img/{idx}/，视频类落 V/{idx}/
+    # 提到 if-block 之外，否则下方 not-found 分支引用时会 UnboundLocalError
+    subdir_map = {'8': 'F', '2': 'Img', '5': 'V', '4': 'A'}
+
     candidates = []
     if os.path.isdir(attach_dir):
         import glob as glob_mod
-        # 文件类（datatype=8）落 F/{idx}/，图片类落 Img/{idx}/，视频类落 V/{idx}/
-        subdir_map = {'8': 'F', '2': 'Img', '5': 'V', '4': 'A'}
         sub = subdir_map.get(datatype, '*')
         idx_str = str(item_index)
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -560,6 +560,40 @@ def _resolve_quote_sender_label(ref_user, ref_display_name, is_group, chat_usern
 _RECORD_XML_PARSE_MAX_LEN = 500_000
 
 
+def _safe_basename(name):
+    """对 user-derived filename（从消息 XML 来，不可信）做严格 sanitize。
+
+    Codex adversarial round 4 建议"reject suspicious input"而不是 normalize：
+    哪怕 os.path.basename 把 '../foo' 剥成 'foo' 是 safe 的，意图依然可疑，
+    应该让工具显式失败让用户看到，而不是默默 normalize 接受。
+    """
+    if not name:
+        return ''
+    if '\x00' in name:
+        return ''
+    if os.path.isabs(name):
+        return ''
+    # 任何 path separator 或 .. component 直接拒（不做 normalize）
+    parts = name.replace('\\', '/').split('/')
+    if any(p in ('', '.', '..') for p in parts) and len(parts) > 1:
+        return ''
+    if len(parts) > 1:
+        return ''
+    if name in ('.', '..'):
+        return ''
+    return name
+
+
+def _path_under_root(path, root):
+    """resolve realpath 后确认仍在 root 下（防 symlink 跳出）。"""
+    try:
+        real_path = os.path.realpath(path)
+        real_root = os.path.realpath(root)
+    except OSError:
+        return False
+    return real_path == real_root or real_path.startswith(real_root + os.sep)
+
+
 def _parse_xml_root(content, max_len=_XML_PARSE_MAX_LEN):
     if not content or len(content) > max_len or _XML_UNSAFE_RE.search(content):
         return None
@@ -1943,7 +1977,7 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
             f"type=5/33/36/44 等是链接/小程序，没有可下载的本地文件"
         )
 
-    title = _collapse_text(appmsg.findtext('title') or '')
+    raw_title = _collapse_text(appmsg.findtext('title') or '')
     fileext = _collapse_text(appmsg.findtext('.//fileext') or '')
     totallen = _parse_int(_collapse_text(appmsg.findtext('.//totallen') or ''), 0)
 
@@ -1951,8 +1985,14 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
     if appmsg.find('appattach') is None:
         return "消息没有 appattach 节点（可能 schema 异常或不是真文件消息）"
 
-    if not title:
+    if not raw_title:
         return "消息中没有文件名 (title)"
+
+    # title 来自不可信的 message XML，对方可能发恶意消息（含绝对路径或 ../）。
+    # 必须 sanitize 成 safe basename 才能拼路径 + glob，否则有 path-traversal 风险。
+    title = _safe_basename(raw_title)
+    if not title:
+        return f"消息中的文件名 {raw_title!r} 不安全（含绝对路径/路径分隔符/..），拒绝处理"
 
     # 性能优化：先按消息时间精确定位 msg/file/{YYYY-MM}/，命中即返回；
     # 否则才退回 walk 全盘 os.walk（msg/attach 含数十万小文件，全盘扫描可达数秒）
@@ -2049,12 +2089,20 @@ def decode_file_message(chat_name: str, local_id: int, create_time: int = 0) -> 
         )
 
     chosen = candidates[0]
+    # realpath 二次验证：拼接后仍在 wechat 缓存根下（防 symlink 跳出）
+    cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
+    if not _path_under_root(chosen, cache_root):
+        return f"匹配到的路径 {chosen!r} 不在 {cache_root} 下，拒绝返回（可能是 symlink 攻击）"
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
         f"  大小: {os.path.getsize(chosen):,} bytes\n"
         f"  扩展名: {fileext or os.path.splitext(title)[1].lstrip('.') or '?'}\n"
-        f"  期望大小: {totallen:,} bytes"
+        f"  期望大小: {totallen:,} bytes\n"
+        f"  ⚠️  此路径基于 (filename + size) 启发式匹配，没有从 wechat 元数据"
+        f"派生唯一证据证明它属于 local_id={local_id} 的消息。如果同 chat 缓存里"
+        f"另有同名同 size 的不相关文件，本工具可能返回错副本。请人工验证 mtime"
+        f"/路径上下文，或使用 Read 工具校对内容是否符合预期。"
     )
 
 
@@ -2176,7 +2224,11 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
 
     item = items[item_index]
     datatype = (item.get('datatype') or '').strip()
-    datatitle = _collapse_text(item.findtext('datatitle') or '')
+    raw_datatitle = _collapse_text(item.findtext('datatitle') or '')
+    # datatitle 来自不可信 XML，sanitize 防 path traversal
+    datatitle = _safe_basename(raw_datatitle) if raw_datatitle else ''
+    if raw_datatitle and not datatitle:
+        return f"该 dataitem 的 datatitle {raw_datatitle!r} 不安全（含绝对路径/分隔符/..），拒绝处理"
     datasize = _parse_int(_collapse_text(item.findtext('datasize') or ''), 0)
     datafmt = _collapse_text(item.findtext('datafmt') or '')
     sourcename = _collapse_text(item.findtext('sourcename') or '')
@@ -2277,13 +2329,21 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int, create_ti
         )
 
     chosen = candidates[0]
+    # realpath 二次验证：拼接后仍在 wechat 缓存根下（防 symlink 跳出）
+    cache_root = os.path.join(WECHAT_BASE_DIR, 'msg')
+    if not _path_under_root(chosen, cache_root):
+        return f"匹配到的路径 {chosen!r} 不在 {cache_root} 下，拒绝返回（可能是 symlink 攻击）"
     return (
         f"找到本地文件:\n"
         f"  路径: {chosen}\n"
         f"  大小: {os.path.getsize(chosen):,} bytes\n"
         f"  期望大小: {datasize:,} bytes\n"
         f"  发送者: {sourcename}\n"
-        f"  类型: [{type_label}] {datatitle or '(无标题)'}"
+        f"  类型: [{type_label}] {datatitle or '(无标题)'}\n"
+        f"  ⚠️  此路径基于 (item_index + filename + size) 启发式匹配，无法从"
+        f"wechat 元数据派生唯一证据证明它属于 local_id={local_id} 的这条 record。"
+        f"如果同 chat 内多条合并卡片碰巧含同位置同名同 size 的文件，本工具可能"
+        f"返回别条 record 的副本。请用 mtime 或人工 inspect 校对。"
     )
 
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -565,6 +565,21 @@ def _parse_xml_root(content):
         return None
 
 
+# 合并转发的 recorditem 内嵌 XML 在 dataitem 数量多时显著超过 20K，
+# 实测含 99 条 dataitem 的卡片可达 ~50KB，用更宽的上限专门解析。
+_RECORD_XML_PARSE_MAX_LEN = 500_000
+
+
+def _parse_record_xml(content):
+    """专用于 recorditem 内嵌 XML 解析，允许更大 payload。"""
+    if not content or len(content) > _RECORD_XML_PARSE_MAX_LEN or _XML_UNSAFE_RE.search(content):
+        return None
+    try:
+        return ET.fromstring(content)
+    except ET.ParseError:
+        return None
+
+
 def _parse_int(value, fallback=0):
     try:
         return int(value)
@@ -688,7 +703,7 @@ def _format_record_message_text(appmsg, title):
     if record_node is None or not record_node.text:
         return f"[聊天记录] {fallback_title}（待加载）"
 
-    inner = _parse_xml_root(record_node.text)
+    inner = _parse_record_xml(record_node.text)
     if inner is None:
         return f"[聊天记录] {fallback_title}"
 
@@ -1996,7 +2011,7 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
     if record_node is None or not record_node.text:
         return "消息中没有 recorditem（datalist 还未加载，请在 wechat 中点开此卡片让客户端拉取）"
 
-    inner = _parse_xml_root(record_node.text)
+    inner = _parse_record_xml(record_node.text)
     if inner is None:
         return "无法解析 recorditem 内嵌 XML"
 
@@ -2042,9 +2057,10 @@ def decode_record_item(chat_name: str, local_id: int, item_index: int) -> str:
         sub = subdir_map.get(datatype, '*')
         idx_str = str(item_index)
 
-        # 精确文件名匹配
+        # 精确文件名匹配（datatitle 可能含 [ ] * ? 等 glob 元字符，必须 escape）
         if datatitle:
-            for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, datatitle)):
+            escaped_title = glob_mod.escape(datatitle)
+            for hit in glob_mod.glob(os.path.join(attach_dir, '*/Rec/*', sub, idx_str, escaped_title)):
                 if hit not in candidates:
                     candidates.append(hit)
 

--- a/tests/test_record_decoders.py
+++ b/tests/test_record_decoders.py
@@ -1,0 +1,313 @@
+"""Helper-level regression tests for the recorditem / decoder additions.
+
+Focused on locking in the bugs fixed across PR #65's many review rounds so
+they don't regress. Covers helpers that are easy to call in isolation:
+
+- `_safe_basename`         path-traversal sanitize (round-4 high #1)
+- `_md5_file_chunked`      streaming hash + size cap (round-6 medium #3)
+- `_parse_message_content` group prefix stripping for both `:\n` and
+                           `:<?xml`/`:<msg` shapes (round-7 high #1)
+- `_parse_app_message_outer` retry-with-wider-limit only fires for
+                           `<type>19</type>` content (round-5 medium #3)
+- `_format_record_message_text` end-to-end expansion of a >20KB outer
+                           type-19 message (round-5 high #1, round-2 P2-1)
+- `_format_record_dataitem` per-datatype rendering for the 14 known
+                           types incl. text / file / image / 视频号 etc.
+
+The two MCP-tool wrappers (decode_file_message / decode_record_item) lean
+heavily on module globals (WECHAT_BASE_DIR, _cache, MSG_DB_KEYS) and the
+real wechat cache layout. They are exercised by real-data smoke runs in
+the PR description rather than mocked here — mocking the entire wechat
+cache tree would dwarf the actual logic under test.
+"""
+
+import hashlib
+import os
+import tempfile
+import unittest
+
+import mcp_server
+
+
+# -------- _safe_basename ----------------------------------------------------
+
+
+class SafeBasenameTests(unittest.TestCase):
+    def test_normal_filename_passes(self):
+        self.assertEqual(mcp_server._safe_basename('normal.pdf'), 'normal.pdf')
+        self.assertEqual(
+            mcp_server._safe_basename('Lec 4- 零和.pdf'), 'Lec 4- 零和.pdf'
+        )
+        self.assertEqual(
+            mcp_server._safe_basename('file (1).pdf'), 'file (1).pdf'
+        )
+
+    def test_absolute_path_rejected(self):
+        self.assertEqual(mcp_server._safe_basename('/etc/passwd'), '')
+
+    def test_parent_dir_rejected(self):
+        # Strict reject — should not return the basename 'sensitive'.
+        self.assertEqual(mcp_server._safe_basename('../../sensitive'), '')
+        self.assertEqual(mcp_server._safe_basename('..'), '')
+
+    def test_path_separator_rejected(self):
+        self.assertEqual(mcp_server._safe_basename('subdir/x.pdf'), '')
+        self.assertEqual(mcp_server._safe_basename('a\\b\\c.pdf'), '')
+
+    def test_nul_rejected(self):
+        self.assertEqual(mcp_server._safe_basename('with\x00nul.pdf'), '')
+
+    def test_empty_or_dot_rejected(self):
+        self.assertEqual(mcp_server._safe_basename(''), '')
+        self.assertEqual(mcp_server._safe_basename('.'), '')
+
+    def test_inner_dots_pass(self):
+        # 'file...with..dots.pdf' has no separator → fine.
+        self.assertEqual(
+            mcp_server._safe_basename('file...with..dots.pdf'),
+            'file...with..dots.pdf',
+        )
+
+
+# -------- _md5_file_chunked -------------------------------------------------
+
+
+class Md5FileChunkedTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(delete=False)
+        self.tmp.write(b'x' * 1000)
+        self.tmp.close()
+        self.addCleanup(lambda: os.unlink(self.tmp.name))
+
+    def test_happy_path_matches_hashlib(self):
+        md5, err = mcp_server._md5_file_chunked(self.tmp.name)
+        self.assertIsNone(err)
+        self.assertEqual(md5, hashlib.md5(b'x' * 1000).hexdigest())
+
+    def test_size_cap_rejects_oversized_file(self):
+        md5, err = mcp_server._md5_file_chunked(self.tmp.name, max_size=500)
+        self.assertIsNone(md5)
+        self.assertIn('超过 md5 校验上限', err)
+
+    def test_missing_file_returns_error(self):
+        md5, err = mcp_server._md5_file_chunked('/tmp/no/such/path/here_xxx')
+        self.assertIsNone(md5)
+        self.assertIsNotNone(err)
+
+
+# -------- _parse_message_content --------------------------------------------
+
+
+class ParseMessageContentTests(unittest.TestCase):
+    def test_legacy_newline_prefix_in_group(self):
+        sender, text = mcp_server._parse_message_content(
+            'wxid_abc:\n<msg>hi</msg>', 1, is_group=True
+        )
+        self.assertEqual(sender, 'wxid_abc')
+        self.assertEqual(text, '<msg>hi</msg>')
+
+    def test_xml_decl_inline_prefix_in_group(self):
+        # round-7 high #1: 'sender:<?xml...' without newline
+        sender, text = mcp_server._parse_message_content(
+            'wxid_abc:<?xml version="1.0"?><msg>x</msg>', 1, is_group=True
+        )
+        self.assertEqual(sender, 'wxid_abc')
+        self.assertTrue(text.startswith('<?xml'))
+
+    def test_msg_inline_prefix_in_group(self):
+        sender, text = mcp_server._parse_message_content(
+            'wxid_abc:<msg>x</msg>', 1, is_group=True
+        )
+        self.assertEqual(sender, 'wxid_abc')
+        self.assertEqual(text, '<msg>x</msg>')
+
+    def test_private_chat_does_not_strip(self):
+        sender, text = mcp_server._parse_message_content(
+            'wxid_abc:<msg>x</msg>', 1, is_group=False
+        )
+        self.assertEqual(sender, '')
+        self.assertEqual(text, 'wxid_abc:<msg>x</msg>')
+
+    def test_bytes_content_returns_marker(self):
+        sender, text = mcp_server._parse_message_content(b'\x00\x01', 1, is_group=False)
+        self.assertEqual(sender, '')
+        self.assertEqual(text, '(二进制内容)')
+
+
+# -------- _parse_app_message_outer ------------------------------------------
+
+
+class ParseAppMessageOuterTests(unittest.TestCase):
+    def test_small_xml_uses_default_path(self):
+        outer = '<msg><appmsg><type>5</type><title>x</title></appmsg></msg>'
+        root = mcp_server._parse_app_message_outer(outer)
+        self.assertIsNotNone(root)
+
+    def test_oversized_non_record_xml_short_circuits(self):
+        # round-5 medium #3: only <type>19</type> content should retry under
+        # the wider 500K cap. A 25KB non-type-19 message must NOT be parsed
+        # under the wider limit.
+        outer = '<msg><appmsg><type>5</type><title>' + 'X' * 25000 + '</title></appmsg></msg>'
+        root = mcp_server._parse_app_message_outer(outer)
+        self.assertIsNone(root)
+
+    def test_oversized_record_xml_retries(self):
+        # type=19 content > 20KB should succeed under the wider cap.
+        big_desc = 'A' * 25000
+        outer = (
+            '<msg><appmsg><type>19</type><title>x</title>'
+            f'<recorditem><![CDATA[<recordinfo><title>x</title>'
+            f'<datalist count="1"><dataitem datatype="1">'
+            f'<datadesc>{big_desc}</datadesc></dataitem></datalist>'
+            f'</recordinfo>]]></recorditem></appmsg></msg>'
+        )
+        self.assertGreater(len(outer), 20000)
+        root = mcp_server._parse_app_message_outer(outer)
+        self.assertIsNotNone(root)
+
+
+# -------- _format_record_dataitem ------------------------------------------
+
+
+class FormatRecordDataitemTests(unittest.TestCase):
+    def _item(self, xml):
+        import xml.etree.ElementTree as ET
+        return ET.fromstring(xml)
+
+    def test_text(self):
+        item = self._item(
+            '<dataitem datatype="1"><datadesc>hello world</datadesc></dataitem>'
+        )
+        self.assertEqual(mcp_server._format_record_dataitem(item), 'hello world')
+
+    def test_file_with_title(self):
+        item = self._item(
+            '<dataitem datatype="8"><datatitle>report.pdf</datatitle></dataitem>'
+        )
+        self.assertEqual(
+            mcp_server._format_record_dataitem(item), '[文件] report.pdf'
+        )
+
+    def test_image(self):
+        item = self._item('<dataitem datatype="2"></dataitem>')
+        self.assertEqual(mcp_server._format_record_dataitem(item), '[图片]')
+
+    def test_finder_feed(self):
+        # round-2 datatype 22 视频号
+        item = self._item(
+            '<dataitem datatype="22"><finderFeed><desc>video desc</desc></finderFeed></dataitem>'
+        )
+        self.assertEqual(
+            mcp_server._format_record_dataitem(item), '[视频号] video desc'
+        )
+
+    def test_music(self):
+        item = self._item(
+            '<dataitem datatype="29"><datatitle>song</datatitle><datadesc>artist</datadesc></dataitem>'
+        )
+        self.assertEqual(
+            mcp_server._format_record_dataitem(item), '[音乐] song - artist'
+        )
+
+    def test_unknown_datatype_falls_back_to_desc(self):
+        item = self._item(
+            '<dataitem datatype="99"><datadesc>fallback content</datadesc></dataitem>'
+        )
+        self.assertEqual(
+            mcp_server._format_record_dataitem(item), 'fallback content'
+        )
+
+    def test_unknown_datatype_with_no_desc_uses_label(self):
+        item = self._item('<dataitem datatype="999"></dataitem>')
+        self.assertEqual(
+            mcp_server._format_record_dataitem(item), '[未知类型 999]'
+        )
+
+
+# -------- _format_record_message_text end-to-end ---------------------------
+
+
+class FormatRecordMessageTextTests(unittest.TestCase):
+    def _outer_with_items(self, items_xml, title='Big card', is_chatroom=False):
+        chatroom = '<isChatRoom>1</isChatRoom>' if is_chatroom else ''
+        recordinfo = (
+            f'<recordinfo><title>{title}</title>{chatroom}'
+            f'<datalist count="{items_xml.count("<dataitem")}">{items_xml}</datalist>'
+            f'</recordinfo>'
+        )
+        return (
+            '<?xml version="1.0"?><msg><appmsg><title>x</title><type>19</type>'
+            f'<recorditem><![CDATA[{recordinfo}]]></recorditem>'
+            '</appmsg></msg>'
+        )
+
+    def test_large_outer_expands_via_app_message_path(self):
+        # round-2 P2-1 + round-5 high #1: 大 outer 端到端必须能展开
+        items_xml = ''.join(
+            f'<dataitem datatype="1"><sourcename>S{i}</sourcename>'
+            f'<sourcetime>2025-01-01 00:00</sourcetime>'
+            f'<datadesc>{"X" * 600}</datadesc></dataitem>'
+            for i in range(40)
+        )
+        outer = self._outer_with_items(items_xml)
+        self.assertGreater(len(outer), 20000)
+        out = mcp_server._format_app_message_text(
+            outer,
+            (19 << 32) | 49,
+            False,
+            'wxid_dummy',
+            'dummy',
+            {},
+        )
+        self.assertIsNotNone(out)
+        self.assertIn('[聊天记录]', out)
+        self.assertIn('共 40 条', out)
+        # 每行带 0-based index
+        self.assertIn('[0] ', out)
+        self.assertIn('[1] ', out)
+
+    def test_empty_datalist_marks_loading(self):
+        # 空 datalist 应展示"（待加载）"而非"共 0 条"
+        outer = (
+            '<?xml version="1.0"?><msg><appmsg><title>x</title><type>19</type>'
+            '<recorditem><![CDATA[<recordinfo><title>x</title>'
+            '<isChatRoom>0</isChatRoom></recordinfo>]]></recorditem>'
+            '</appmsg></msg>'
+        )
+        out = mcp_server._format_app_message_text(
+            outer, (19 << 32) | 49, False, 'd', 'd', {}
+        )
+        self.assertIn('待加载', out)
+
+    def test_chatroom_marker_appended(self):
+        items_xml = (
+            '<dataitem datatype="1"><sourcename>A</sourcename>'
+            '<datadesc>hi</datadesc></dataitem>'
+        )
+        outer = self._outer_with_items(items_xml, title='G', is_chatroom=True)
+        out = mcp_server._format_app_message_text(
+            outer, (19 << 32) | 49, True, 'd', 'd', {}
+        )
+        self.assertIn('群聊转发', out)
+
+    def test_overflow_truncation_marker(self):
+        # > _RECORD_MAX_ITEMS dataitems should produce a
+        # "…（还有 N 条未显示）" line.
+        original_max = mcp_server._RECORD_MAX_ITEMS
+        try:
+            mcp_server._RECORD_MAX_ITEMS = 3
+            items_xml = ''.join(
+                f'<dataitem datatype="1"><datadesc>m{i}</datadesc></dataitem>'
+                for i in range(7)
+            )
+            outer = self._outer_with_items(items_xml)
+            out = mcp_server._format_app_message_text(
+                outer, (19 << 32) | 49, False, 'd', 'd', {}
+            )
+            self.assertIn('还有 4 条未显示', out)
+        finally:
+            mcp_server._RECORD_MAX_ITEMS = original_max
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 背景

合并转发的聊天记录（微信内"选择多条消息→转发"的卡片，appmsg `type=19`）是
日常聊天高频场景，但原版 mcp_server 把这类消息 fallback 显示成：

```
[链接/文件] xxx的聊天记录
```

调用 LLM 看不到任何内嵌内容（发件人、文本、文件名、图片占位），完全失明。

## 改动

### 1. `_format_app_message_text` 增加 `app_type == 19` 分支

新增 `_format_record_message_text` helper 解析 `<recorditem>` CDATA 里的
内嵌 `<recordinfo>` XML，遍历 `<datalist>/<dataitem>` 按 `datatype`
格式化输出（人名/文件名已做匿名处理）：

```
[聊天记录] Chat History for contactA,共 8 条:
  2025-10-29 17:59 contactA: [文件] file_a.pdf
  2025-10-29 17:59 contactA: [文件] file_b.pdf
  2025-10-17 10:44 contactA: [文件] file_c.pdf
  ...
```

覆盖 14 种 datatype：

| datatype | 含义 | 输出格式 |
|---|---|---|
| 1 | 文本 | `<datadesc>` 直接显示 |
| 2 | 图片 | `[图片]` |
| 3 | 名片 | `[名片]` |
| 4 | 语音 | `[语音]` |
| 5 | 视频 | `[视频]` |
| 6 | 链接 | `[链接] {datatitle}` |
| 7 | 位置 | `[位置]` |
| 8 | 文件 | `[文件] {datatitle}` |
| 17 | 嵌套聊天记录 | `[聊天记录] {datatitle}` |
| 19 | 小程序 | `[小程序] {appbranditem/sourcedisplayname}` |
| 22 | 视频号 | `[视频号] {finderFeed/desc}` |
| 23 | 视频号直播 | `[视频号直播]` |
| 29 | 音乐 | `[音乐] {datatitle} - {datadesc}` |
| 36 | 小程序/H5 | `[小程序/H5] {datatitle}` |
| 37 | 表情包 | `[表情包]` |

边界处理：
- 空 datalist（CDN 未回填）→ `[聊天记录] xxx（待加载）`
- 群聊转发自动加 `（群聊转发）` 标记
- 超过 50 条 → `…（还有 N 条未显示）`
- 单条文本超过 200 字 → 截断 + `…`

### 2. `decode_file_message(chat_name, local_id)` 新工具

获取外层独立文件消息（`type=49+sub=6`，对方直接发来的 PDF/docx 等）的
本地副本路径。微信会把这类文件下载到：

```
~/Library/.../xwechat_files/{wxid}/msg/file/{YYYY-MM}/原文件名.{ext}
```

工具内置路径模式 + size 二次确认，处理同名 `(1)(2)` 后缀，可直接喂给
`Read` / PDF 解析工具。

### 3. `decode_record_item(chat_name, local_id, item_index)` 新工具

获取合并转发记录里第 N 个 dataitem 的本地副本路径。微信在用户点击查看
合并卡片中的文件后，会下载到：

```
msg/attach/{md5(chat_username)}/{YYYY-MM}/Rec/{record_hash}/F/{item_index}/{原文件名}
```

工具按 `chat_username` md5 → table_hash 限定 chat，按 `item_index` 限定
合并里的位置，按 `datasize` 二次确认，避免误命中。

未下载场景下给精确指引（人名已匿名）：

```
在本地缓存中找不到此 dataitem（很可能未在 wechat 客户端点击查看过）
  消息: contactA 的 local_id=142
  dataitem[0]: contactB: [文件] file_a.pdf
  期望大小: 333,035 bytes
  解决方法: 在 wechat 客户端打开此合并记录卡片，点击第 1 项让客户端下载，再试
```

## 回归测试

在 macOS 微信 4.x 数千条真实合并转发消息上回归：

| 指标 | 数值 |
|---|---|
| 完美展开 datalist 内容 | ~83% |
| 含未知 datatype 输出 | 0 |
| 触发异常 | 0 |
| `[链接/文件]` fallback 占比（未变差） | ~17%（content 缺失/被撤回，行为与改前一致） |

`decode_file_message` / `decode_record_item` 在含直接发送的 PDF + 合并转发
内嵌文件的真实场景下测试通过，含未下载场景的精确提示。

## 局限

- **合并转发里的内嵌文件需要用户先在 wechat 客户端点击触发下载** —— 这是
  微信客户端的设计（卡片本身只含 CDN URL+aeskey，不预下载）。
  `decode_record_item` 在未下载时不会自己走 CDN 协议（避免逆向 +
  反 bot 风险），而是返回精确指引提示用户去客户端点击。
- 仅 macOS 路径（Windows/Linux 路径模式可能不同；如果 reviewer 有相关
  机器可以协助验证欢迎评论）。

## 关联

- 无现有 issue 提及此功能
- 最接近的 #44/#45 是关于引用回复（`type=57`），与本 PR 涵盖的 `type=19`
  合并转发是完全不同的消息类型
