### PR TITLE
fix: monitor_web 用 webbrowser.open 替代 cmd.exe 实现跨平台开浏览器

### DIFF
--- a/monitor_web.py
+++ b/monitor_web.py
@@ -2096,7 +2096,8 @@ def main():
     print("Ctrl+C 停止\n", flush=True)
 
     try:
-        os.system(f'cmd.exe /c start http://localhost:{PORT}')
+        import webbrowser
+        webbrowser.open(f'http://localhost:{PORT}')
     except Exception:
         pass
 


### PR DESCRIPTION
## 问题

`monitor_web.py` 在 main() 启动 HTTP server 后调用:

```py
try:
    os.system(f'cmd.exe /c start http://localhost:{PORT}')
except Exception:
    pass
```

非 Windows 平台 cmd.exe 不存在,`os.system` 返回非零退出码 (不抛异常,所以
外层 except 抓不到),调用静默失败;shell 还会把 `cmd.exe: command not found`
写到终端 stderr 干扰用户 → 自动开浏览器功能在 Linux / macOS 完全失效,
用户只能手动复制 URL。

## 修改

改用 Python 标准库 `webbrowser.open()`,跨平台自动选默认浏览器,无新增依赖。

## 测试

macOS 本地验证: `python3 monitor_web.py` 启动后默认浏览器自动打开
`http://localhost:<PORT>`,终端不再有 `cmd.exe: command not found` 噪声。
`webbrowser` 是标准库,Linux / Windows 跨平台行为有官方文档保障。
