### PR TITLE
fix: find_image_key 三个 fallback 入口路径展开 + 方案2 hint

### DIFF
--- a/find_image_key.py
+++ b/find_image_key.py
@@ -337,7 +337,7 @@ def main():
     with open(config_path, encoding="utf-8") as f:
         config = json.load(f)
 
-    db_dir = config['db_dir']
+    db_dir = os.path.expanduser(os.path.expandvars(config['db_dir']))
     base_dir = os.path.dirname(db_dir)
     attach_dir = os.path.join(base_dir, 'msg', 'attach')
 

--- a/find_image_key_macos.py
+++ b/find_image_key_macos.py
@@ -494,6 +494,8 @@ def _find_via_bruteforce(db_dir, attach_dir, templates):
     if not xres:
         print("[!] 方案2: V2 .dat 样本不足 (需 >= 3 个), 无法投票反推 xor_key",
               flush=True)
+        print("    请先在微信中再看 1-2 张图片，让微信生成更多 V2 .dat 文件",
+              flush=True)
         return None
     xor_key, votes, total = xres
     if votes == total:

--- a/find_image_key_macos.py
+++ b/find_image_key_macos.py
@@ -607,6 +607,7 @@ def main(config_path=None):
     if not db_dir:
         print("[!] config.json 中未配置 db_dir", file=sys.stderr, flush=True)
         sys.exit(1)
+    db_dir = os.path.expanduser(os.path.expandvars(db_dir))
     print(f"[*] db_dir = {db_dir}", flush=True)
 
     # 短路：如果已有 image_aes_key 且仍能在所有模板上验证通过，直接退出

--- a/find_image_key_monitor.py
+++ b/find_image_key_monitor.py
@@ -230,7 +230,7 @@ def main():
     with open(config_path, encoding="utf-8") as f:
         config = json.load(f)
 
-    db_dir = config['db_dir']
+    db_dir = os.path.expanduser(os.path.expandvars(config['db_dir']))
     base_dir = os.path.dirname(db_dir)
     attach_dir = os.path.join(base_dir, 'msg', 'attach')
 


### PR DESCRIPTION
两条相邻 fix, 围绕 PR #60 落地后 macOS 用户反馈浮出的问题. 拆成两个 commit 方便分别看.

## 1. 三个 fallback CLI 入口对齐 `config.load_config` 路径展开

PR #63 给 `config.load_config()` 加了 `expanduser` + `expandvars`, 但
`find_image_key.py` / `find_image_key_macos.py` / `find_image_key_monitor.py`
三个 CLI 入口的 `main()` 走 raw `json.load(config_path)` 没经过
`load_config`. 这是有意为之的 — `find_image_key_macos.py:589` docstring
写得很清楚: "暴露此参数主要为方便单元测试注入隔离的临时配置". 所以本 PR
不动 raw `json.load`, 只在三个 main() 里各补 1 行展开.

用户 `config.json` 里写:

```json
"db_dir": "~/Documents/xwechat_files/<wxid>/db_storage"
```

(macOS 用户最自然的写法) 时, `db_dir` 字符串字面带 `~`, 下游 `attach_dir`
拼出仍带 `~`, glob `*_t.dat` 扫不到:

- `find_image_key.py` / `find_image_key_monitor.py` → 报 "No V2 .dat files found"
- `find_image_key_macos.py` → dispatcher 层 (line 552) 误报 "请先在微信中
  查看 1-2 张图片让微信生成 V2 .dat 文件"

但实际磁盘上 `attach/` 已经塞满 `.dat`. 三个文件各加 1 行
`os.path.expanduser(os.path.expandvars(...))` 修复.

## 2. macOS 方案2 V2 `_t.dat` 样本不足时缺下一步指引

`find_image_key_macos.py` dispatcher 层 (找不到 V2 模板分支) 已有"请先
在微信中查看 1-2 张图片让微信生成 V2 .dat 文件"指引, 但
`_find_via_bruteforce` 子路径在 V2 `_t.dat` 样本 < 3 时只 print "样本不足
(需 >= 3 个), 无法投票反推 xor_key", 用户不知下一步. 补一行等价 hint.

## 测试

macOS 本地: `config.json` 里 `db_dir` 改成 `~/Documents/...` 重跑, 不再
误报模板缺失. 把 `attach/` 下 V2 `_t.dat` 临时移走只留 1 个重跑, 看到
新加的 hint 行.

`find_image_key.py` / `find_image_key_monitor.py` 上游无对应 `tests/`,
改动只是单行 stdlib 路径展开 (`expanduser` / `expandvars` 三平台行为有
官方文档保障), 对绝对路径 no-op, 风险最小化.
